### PR TITLE
use placeholder for pr template before ci ready

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
+I hereby agree to the terms of the CLA available at: [placeholder]
 
 Changelog category (leave one):
 - New Feature
@@ -21,9 +21,6 @@ Detailed description / Documentation draft:
 
 ...
 
-By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.
 
-If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.
+If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ByConity Documentation](https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md) guide first.
 
-
-Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/

--- a/utils/github/parser.py
+++ b/utils/github/parser.py
@@ -38,7 +38,7 @@ class Description:
                 category = stripped
                 next_category = False
 
-            if stripped == 'I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en':
+            if stripped == 'I hereby agree to the terms of the CLA available at: [placeholder]':
                 self.legal = True
 
             category_headers = (


### PR DESCRIPTION


Changelog category (leave one):
- Documentation (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


use placeholder for pr template before ci ready

...

