### PR TITLE
bypass db lock when creating table by default

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -751,7 +751,7 @@ class IColumn;
     \
     /* Transaction and catalog */ \
     M(Bool, ignore_duplicate_insertion_label, true, "Throw an exception if false", 0) \
-    M(Bool, bypass_ddl_db_lock, false, "Bypass locking database while creating tables", 0) \
+    M(Bool, bypass_ddl_db_lock, true, "Bypass locking database while creating tables", 0) \
     M(Bool, prefer_cnch_catalog, false, "Force using cnch catalog to get table first when resolving database and table", 0) \
     /** The section above is for obsolete settings. Do not add anything there. */\
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [placeholder]

Changelog category (leave one):
- Settings


...


Detailed description / Documentation draft:
- Bypass db lock by default, better distributed lock server needs to wait for the implementation of distributed lock

...


If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ByConity Documentation](https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md) guide first.

