### PR TITLE
Remove buffer size assertion during loading marks

### DIFF
--- a/src/Disks/HDFS/DiskByteHDFS.cpp
+++ b/src/Disks/HDFS/DiskByteHDFS.cpp
@@ -177,7 +177,7 @@ void DiskByteHDFS::listFiles(const String & path, std::vector<String> & file_nam
 
 std::unique_ptr<ReadBufferFromFileBase> DiskByteHDFS::readFile(const String & path, const ReadSettings & settings) const
 {
-    return std::make_unique<ReadBufferFromByteHDFS>(absolutePath(path), true, hdfs_params, settings.buffer_size);
+    return std::make_unique<ReadBufferFromByteHDFS>(absolutePath(path), settings.byte_hdfs_pread, hdfs_params, settings.buffer_size);
 }
 
 std::unique_ptr<WriteBufferFromFileBase> DiskByteHDFS::writeFile(const String & path, const WriteSettings & settings)

--- a/src/IO/ReadSettings.h
+++ b/src/IO/ReadSettings.h
@@ -32,6 +32,7 @@ struct ReadSettings
     size_t mmap_threshold = 0;
 
     MMappedFileCache* mmap_cache = nullptr;
+    bool byte_hdfs_pread = true;
 };
 
 }

--- a/src/Storages/MergeTree/MergeTreeReaderStream.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderStream.cpp
@@ -145,7 +145,7 @@ MergeTreeReaderStream::MergeTreeReaderStream(
                     .estimated_size = sum_mark_range_bytes,
                     .aio_threshold = settings.min_bytes_to_use_direct_io,
                     .mmap_threshold = settings.min_bytes_to_use_mmap_io,
-                    settings.mmap_cache.get()
+                    .mmap_cache = settings.mmap_cache.get()
                 }
             ),
             /* allow_different_codecs = */false,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [placeholder]

Changelog category (leave one):
- Bug Fix


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
remove buffer size assertion during loading marks, solve issue #80 
...


Detailed description / Documentation draft:
The buffer size is not always equals to file size due the use of pread and read_all_once set to false in `ReadBufferFromByteHDFS`.  `hdfsPRead` may return the buffer size less than the requested read size even if eof is not reach. `ReadBufferFromByteHDFS` will shrink the working buffer in this case.
...


If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ByConity Documentation](https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md) guide first.

