### PR TITLE
Temporary not droping database after test in CI

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -373,33 +373,33 @@ def run_single_test(args, ext, server_logs_level, client_options, case_file, std
     while (datetime.now() - start_time).total_seconds() < args.timeout and proc.poll() is None:
         sleep(0.01)
 
-    need_drop_database = not args.database
-    if need_drop_database and args.no_drop_if_fail:
-        maybe_passed = (proc.returncode == 0) and (proc.stderr is None) and (proc.stdout is None or 'Exception' not in proc.stdout)
-        need_drop_database = not maybe_passed
+    # need_drop_database = not args.database
+    # if need_drop_database and args.no_drop_if_fail:
+    #     maybe_passed = (proc.returncode == 0) and (proc.stderr is None) and (proc.stdout is None or 'Exception' not in proc.stdout)
+    #     need_drop_database = not maybe_passed
 
-    if need_drop_database:
-        with open(stderr_file, 'a') as stderr:
-            clickhouse_proc_create = Popen(shlex.split(client), stdin=PIPE, stdout=PIPE, stderr=stderr, universal_newlines=True)
-        seconds_left = max(args.timeout - (datetime.now() - start_time).total_seconds(), 20)
-        try:
-            drop_database_query = "DROP DATABASE " + database
-            if args.replicated_database:
-                drop_database_query += " ON CLUSTER test_cluster_database_replicated"
-            clickhouse_proc_create.communicate((drop_database_query), timeout=seconds_left)
-        except TimeoutExpired:
-            # kill test process because it can also hung
-            if proc.returncode is None:
-                try:
-                    proc.kill()
-                except OSError as e:
-                    if e.errno != ESRCH:
-                        raise
+    # if need_drop_database:
+    #     with open(stderr_file, 'a') as stderr:
+    #         clickhouse_proc_create = Popen(shlex.split(client), stdin=PIPE, stdout=PIPE, stderr=stderr, universal_newlines=True)
+    #     seconds_left = max(args.timeout - (datetime.now() - start_time).total_seconds(), 20)
+    #     try:
+    #         drop_database_query = "DROP DATABASE " + database
+    #         if args.replicated_database:
+    #             drop_database_query += " ON CLUSTER test_cluster_database_replicated"
+    #         clickhouse_proc_create.communicate((drop_database_query), timeout=seconds_left)
+    #     except TimeoutExpired:
+    #         # kill test process because it can also hung
+    #         if proc.returncode is None:
+    #             try:
+    #                 proc.kill()
+    #             except OSError as e:
+    #                 if e.errno != ESRCH:
+    #                     raise
 
-            total_time = (datetime.now() - start_time).total_seconds()
-            return clickhouse_proc_create, "", "Timeout dropping database {} after test".format(database), total_time
+    #         total_time = (datetime.now() - start_time).total_seconds()
+    #         return clickhouse_proc_create, "", "Timeout dropping database {} after test".format(database), total_time
 
-        shutil.rmtree(args.test_tmp_dir)
+    #     shutil.rmtree(args.test_tmp_dir)
 
     total_time = (datetime.now() - start_time).total_seconds()
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [placeholder]

Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Many timeout errors while drop databases, not from engine side

https://github.com/ByConity/ByConity/actions/runs/4222028382/jobs/7330026867

https://github.com/ByConity/ByConity/actions/runs/4222028382

https://github.com/ByConity/ByConity/actions/runs/4219763995/jobs/7325435279


If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ByConity Documentation](https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md) guide first.

