### PR TITLE
revert code that disable PartClustering in DM

### DIFF
--- a/src/DaemonManager/DaemonManager.cpp
+++ b/src/DaemonManager/DaemonManager.cpp
@@ -175,7 +175,7 @@ std::unordered_map<CnchBGThreadType, DaemonJobServerBGThreadPtr> createDaemonJob
         { "PART_MERGE", 10000},
         { "CONSUMER", 10000},
         { "DEDUP_WORKER", 10000},
-        //{ "PART_CLUSTERING", 10000}
+        { "PART_CLUSTERING", 10000}
     };
 
     std::map<std::string, unsigned int> config = updateConfig(std::move(default_config), app_config);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [placeholder]

Changelog category (leave one):
- New Feature
- Bug Fix
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Other
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

...


If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ByConity Documentation](https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md) guide first.

