### PR TITLE
Use VW pool as the only way for getting clients

### DIFF
--- a/src/CloudServices/CnchMergeMutateThread.cpp
+++ b/src/CloudServices/CnchMergeMutateThread.cpp
@@ -405,7 +405,7 @@ void CnchMergeMutateThread::runImpl()
             std::lock_guard lock(worker_pool_mutex);
             vw_name = storage.getSettings()->cnch_vw_write;
             /// TODO: pick_worker_algo = storage.getSettings()->cnch_merge_pick_worker_algo;
-            worker_pool = getContext()->getCnchWorkerClientPools().getPool(vw_name);
+            vw_handle = getContext()->getVirtualWarehousePool().get(vw_name);
         }
 
         bool merge_success = false;
@@ -832,7 +832,7 @@ String CnchMergeMutateThread::triggerPartMerge(
             std::lock_guard pool_lock(worker_pool_mutex);
             vw_name = storage_settings->cnch_vw_write;
             /// pick_worker_algo = storage_settings->cnch_merge_pick_worker_algo;
-            worker_pool = local_context->getCnchWorkerClientPools().getPool(vw_name);
+            vw_handle = getContext()->getVirtualWarehousePool().get(vw_name);
         }
 
         return submitFutureManipulationTask(
@@ -974,32 +974,10 @@ void CnchMergeMutateThread::finishTask(const String & task_id, const MergeTreeDa
     updatePartCache(curr_task->parts.front()->info().partition_id, curr_task->parts.size());
 }
 
-CnchWorkerClientPtr CnchMergeMutateThread::getWorker(ManipulationType type, [[maybe_unused]] const ServerDataPartsVector & all_parts)
+CnchWorkerClientPtr CnchMergeMutateThread::getWorker([[maybe_unused]] ManipulationType type, [[maybe_unused]] const ServerDataPartsVector & all_parts)
 {
     std::lock_guard lock(worker_pool_mutex);
-
-    /// FIXME: (zuochuang.zema) refactor this feature later.
-    // if (pick_worker_algo == "RoundRobin")
-    // {
-    if (ManipulationType::Merge == type)
-        return worker_pool->get();
-    return worker_pool->get();
-    // }
-
-    // ResourceRequirement requirement{};
-    // UInt64 part_bytes = 0;
-    // for (auto & part : all_parts)
-    //     part_bytes += part->part_model().size();
-    // requirement.request_disk_bytes = part_bytes;
-
-    /// Try to pick worker from RM (use vw handle).
-    // auto vw = getContext()->getVirtualWarehousePool().get(vw_name);
-    // auto host_ports = vw->tryPickWorkerFromRM(VWScheduleAlgo::GlobalLowCpu, requirement);
-    // if (host_ports)
-    //     return worker_pool->get(host_ports.value());
-
-    // LOG_TRACE(log, "Resource Manager result is invalid, pick one locally.");
-    // return worker_pool->get();
+    return vw_handle->getWorker();
 }
 
 bool CnchMergeMutateThread::needCollectExtendedMergeMetrics()

--- a/src/CloudServices/CnchMergeMutateThread.h
+++ b/src/CloudServices/CnchMergeMutateThread.h
@@ -17,6 +17,8 @@
 #include <CloudServices/ICnchBGThread.h>
 
 #include <Catalog/DataModelPartWrapper_fwd.h>
+#include <Interpreters/VirtualWarehouseHandle.h>
+#include <Interpreters/VirtualWarehousePool.h>
 #include <Storages/MergeTree/CnchMergeTreeMutationEntry.h>
 #include <Storages/MergeTree/IMergeTreeDataPart_fwd.h>
 #include <Transaction/ICnchTransaction.h>
@@ -29,8 +31,6 @@ namespace DB
 
 class CnchWorkerClient;
 using CnchWorkerClientPtr = std::shared_ptr<CnchWorkerClient>;
-using CnchWorkerClientPool = RpcClientPool<CnchWorkerClient>;
-using CnchWorkerClientPoolPtr = std::shared_ptr<CnchWorkerClientPool>;
 
 class CnchMergeMutateThread;
 struct PartMergeLogElement;
@@ -193,7 +193,7 @@ private:
     std::mutex worker_pool_mutex;
     String vw_name;
     String pick_worker_algo;
-    CnchWorkerClientPoolPtr worker_pool;
+    VirtualWarehouseHandle vw_handle;
 
     std::atomic_bool shutdown_called{false};
 

--- a/src/CloudServices/CnchWorkerClientPools.h
+++ b/src/CloudServices/CnchWorkerClientPools.h
@@ -27,6 +27,8 @@ using CnchWorkerClientPoolPtr = std::shared_ptr<CnchWorkerClientPool>;
 using ResourceManagement::VirtualWarehouseType;
 using ResourceManagement::VirtualWarehouseTypes;
 
+/// The cache for worker clients.
+/// To get a specific VW (or workers of the VW), please use VirtualWarehousePool and VirtualWarehouseHandle.
 class CnchWorkerClientPools
 {
 public:
@@ -37,10 +39,6 @@ public:
 
     void addVirtualWarehouse(const String & name, const String & psm, VirtualWarehouseTypes vw_types);
     void removeVirtualWarehouse(const String & name);
-
-    CnchWorkerClientPoolPtr getPool(VirtualWarehouseType vw_type);
-    CnchWorkerClientPoolPtr getPool(const Strings & names, VirtualWarehouseTypes vw_types);
-    CnchWorkerClientPoolPtr getPool(const String & name);
 
     CnchWorkerClientPtr getWorker(const HostWithPorts & host_ports);
 

--- a/src/CloudServices/DedupWorkerManager.cpp
+++ b/src/CloudServices/DedupWorkerManager.cpp
@@ -103,11 +103,8 @@ void DedupWorkerManager::assignDeduperToWorker(StoragePtr & storage)
 
 void DedupWorkerManager::selectDedupWorker(StorageCnchMergeTree & cnch_table)
 {
-    if (!worker_pool)
-        worker_pool = getContext()->getCnchWorkerClientPools().getPool(
-            {cnch_table.getSettings()->cnch_vw_task, cnch_table.getSettings()->cnch_vw_write, cnch_table.getSettings()->cnch_vw_default},
-            {VirtualWarehouseType::Task, VirtualWarehouseType::Write, VirtualWarehouseType::Default});
-    worker_client = worker_pool->get();
+    auto vw_handle = getContext()->getVirtualWarehousePool().get(cnch_table.getSettings()->cnch_vw_write);
+    worker_client = vw_handle->getWorker();
 }
 
 void DedupWorkerManager::stopDeduperWorker()

--- a/src/CloudServices/DedupWorkerManager.h
+++ b/src/CloudServices/DedupWorkerManager.h
@@ -18,6 +18,8 @@
 #include <CloudServices/ICnchBGThread.h>
 #include <CloudServices/CnchWorkerClientPools.h>
 #include <CloudServices/DedupWorkerStatus.h>
+#include <Interpreters/VirtualWarehouseHandle.h>
+#include <Interpreters/VirtualWarehousePool.h>
 #include <Storages/IStorage_fwd.h>
 
 namespace DB
@@ -63,7 +65,6 @@ private:
     String getDedupWorkerDebugInfo();
 
     mutable std::mutex worker_client_mutex;
-    CnchWorkerClientPoolPtr worker_pool;
     CnchWorkerClientPtr worker_client;
     StorageID worker_storage_id;
 

--- a/src/Interpreters/VirtualWarehouseHandle.cpp
+++ b/src/Interpreters/VirtualWarehouseHandle.cpp
@@ -360,9 +360,9 @@ std::vector<CnchWorkerClientPtr> VirtualWarehouseHandleImpl::getAllWorkers()
 {
     std::vector<CnchWorkerClientPtr> res;
     std::lock_guard lock(state_mutex);
-    for (auto const & [_, wg_handle] : worker_groups)
+    for (const auto & [_, wg_handle] : worker_groups)
     {
-        auto & workers = wg_handle->getWorkerClients();
+        const auto & workers = wg_handle->getWorkerClients();
         res.insert(res.end(), workers.begin(), workers.end());
     }
     return res;

--- a/src/Interpreters/VirtualWarehouseHandle.cpp
+++ b/src/Interpreters/VirtualWarehouseHandle.cpp
@@ -235,7 +235,7 @@ bool VirtualWarehouseHandleImpl::updateWorkerGroupsFromPSM()
                 worker_groups.try_emplace(
                     group_id, std::make_shared<WorkerGroupHandleImpl>(group_id, WorkerGroupHandleSource::PSM, name, hosts, getContext()));
             else if (!HostWithPorts::isExactlySameVec(
-                         it->second->getHostWithPortsVec(), hosts)) /// replace with the new one bacause of diff
+                         it->second->getHostWithPortsVec(), hosts)) /// replace with the new one because of diff
                 worker_groups.try_emplace(
                     group_id, std::make_shared<WorkerGroupHandleImpl>(group_id, WorkerGroupHandleSource::PSM, name, hosts, getContext()));
             else /// reuse the old one

--- a/src/Interpreters/VirtualWarehouseHandle.h
+++ b/src/Interpreters/VirtualWarehouseHandle.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <Common/Exception.h>
+#include <CloudServices/CnchWorkerClient.h>
 #include <Interpreters/Context_fwd.h>
 #include <ResourceManagement/CommonData.h>
 #include <ResourceManagement/VWScheduleAlgo.h>
@@ -82,6 +83,7 @@ private:
 public:
     using Container = std::unordered_map<String, WorkerGroupHandle>;
     using VirtualWarehouseHandle = std::shared_ptr<VirtualWarehouseHandleImpl>;
+    using CnchWorkerClientPtr = std::shared_ptr<CnchWorkerClient>;
     using VWScheduleAlgo = ResourceManagement::VWScheduleAlgo;
     using Requirement = ResourceManagement::ResourceRequirement;
     using WorkerGroupMetrics = ResourceManagement::WorkerGroupMetrics;
@@ -108,6 +110,10 @@ public:
     std::optional<HostWithPorts> tryPickWorkerFromRM(VWScheduleAlgo algo, const Requirement & requirement = {});
 
     bool addWorkerGroup(const WorkerGroupHandle & worker_group);
+
+    CnchWorkerClientPtr getWorker();
+    CnchWorkerClientPtr getWorkerByHash(const String & key);
+    std::vector<CnchWorkerClientPtr> getAllWorkers();
 
 private:
     bool addWorkerGroupImpl(const WorkerGroupHandle & worker_group, const std::lock_guard<std::mutex> & lock);

--- a/src/Interpreters/WorkerGroupHandle.cpp
+++ b/src/Interpreters/WorkerGroupHandle.cpp
@@ -142,9 +142,9 @@ WorkerGroupHandleImpl::WorkerGroupHandleImpl(const WorkerGroupHandleImpl & from,
 
 CnchWorkerClientPtr WorkerGroupHandleImpl::getWorkerClientByHash(const String & key) const
 {
-    UInt64 index = std::hash<String>{}(key);
-    if (worker_clients.empty() || index >= worker_clients.size())
+    if (worker_clients.empty())
         throw Exception("No available worker for " + id, ErrorCodes::RESOURCE_MANAGER_NO_AVAILABLE_WORKER);
+    UInt64 index = std::hash<String>{}(key) % worker_clients.size();
     return worker_clients[index];
 }
 

--- a/src/Interpreters/WorkerGroupHandle.cpp
+++ b/src/Interpreters/WorkerGroupHandle.cpp
@@ -140,6 +140,26 @@ WorkerGroupHandleImpl::WorkerGroupHandleImpl(const WorkerGroupHandleImpl & from,
     }
 }
 
+CnchWorkerClientPtr WorkerGroupHandleImpl::getWorkerClientByHash(const String & key) const
+{
+    UInt64 index = std::hash<String>{}(key);
+    if (worker_clients.empty() || index >= worker_clients.size())
+        throw Exception("No available worker for " + id, ErrorCodes::RESOURCE_MANAGER_NO_AVAILABLE_WORKER);
+    return worker_clients[index];
+}
+
+CnchWorkerClientPtr WorkerGroupHandleImpl::getWorkerClient() const
+{
+    if (worker_clients.empty())
+        throw Exception("No available worker for " + id, ErrorCodes::RESOURCE_MANAGER_NO_AVAILABLE_WORKER);
+    if (worker_clients.size() == 1)
+        return worker_clients[0];
+
+    std::uniform_int_distribution dist;
+    auto index = dist(thread_local_rng) % worker_clients.size();
+    return worker_clients[index];
+}
+
 CnchWorkerClientPtr WorkerGroupHandleImpl::getWorkerClient(const HostWithPorts & host_ports) const
 {
     if (auto index = indexOf(host_ports))
@@ -207,18 +227,6 @@ std::vector<std::pair<String, UInt16>> WorkerGroupHandleImpl::getReadWorkers() c
         res.emplace_back(conn->getHost(), conn->getPort());
     }
     return res;
-}
-
-HostWithPorts WorkerGroupHandleImpl::randomWorker() const
-{
-    if (hosts.empty())
-        throw Exception("No available worker for " + id, ErrorCodes::RESOURCE_MANAGER_NO_AVAILABLE_WORKER);
-    if (hosts.size() == 1)
-        return hosts[0];
-
-    std::uniform_int_distribution dist;
-    auto index = dist(thread_local_rng) % hosts.size();
-    return hosts[index];
 }
 
 }

--- a/src/Interpreters/WorkerGroupHandle.h
+++ b/src/Interpreters/WorkerGroupHandle.h
@@ -104,6 +104,8 @@ public:
     const auto & getWorkerClients() const { return worker_clients; }
     const ShardsInfo & getShardsInfo() const { return shards_info; }
 
+    CnchWorkerClientPtr getWorkerClient() const;
+    CnchWorkerClientPtr getWorkerClientByHash(const String & key) const;
     CnchWorkerClientPtr getWorkerClient(const HostWithPorts & host_ports) const;
 
     std::optional<size_t> indexOf(const HostWithPorts & host_ports) const
@@ -124,7 +126,6 @@ public:
     Strings getWorkerTCPAddresses(const Settings & settings) const;
     Strings getWorkerIDVec() const;
     std::vector<std::pair<String, UInt16>> getReadWorkers() const;
-    HostWithPorts randomWorker() const;
 
     bool hasRing() const { return ring != nullptr; }
     const DB::ConsistentHashRing & getRing() const { return *ring; }

--- a/src/ResourceManagement/ResourceTracker.cpp
+++ b/src/ResourceManagement/ResourceTracker.cpp
@@ -35,6 +35,7 @@ ResourceTracker::ResourceTracker(ResourceManagerController & rm_controller_)
     : rm_controller(rm_controller_)
     , log(&Poco::Logger::get("ResourceTracker"))
     , background_task(getContext()->getSchedulePool().createTask("ResourceTrackerTask", [&](){ clearLostWorkers(); }))
+    , register_granularity_sec(getContext()->getRootConfig().resource_manager.worker_register_visible_granularity_sec.value)
 {
     background_task->activateAndSchedule();
 }

--- a/src/Storages/Kafka/CnchKafkaConsumeManager.h
+++ b/src/Storages/Kafka/CnchKafkaConsumeManager.h
@@ -103,7 +103,6 @@ private:
     std::vector<ConsumerInfo> consumer_infos;
     KafkaConsumerSchedulerPtr consumer_scheduler;
 
-    CnchWorkerClientPoolPtr worker_pool;
     std::atomic<bool> cloud_table_has_unique_key{false};
 
     UInt64 exception_occur_times{0};

--- a/src/Storages/Kafka/CnchKafkaConsumerScheduler.cpp
+++ b/src/Storages/Kafka/CnchKafkaConsumerScheduler.cpp
@@ -27,16 +27,11 @@ namespace DB
         initOrUpdateWorkerPool();
     }
 
+    /// TODO: (zuochuang.zema, renqiang) maybe it's unnecessary as vw_handle can get newest workers automatically.
     void IKafkaConsumerScheduler::initOrUpdateWorkerPool()
     {
-        /// Here updating for `worker_pool` will be triggered
-        if (worker_pool && !worker_pool->empty())
-            return;
-
-        worker_pool = global_context->getCnchWorkerClientPools().getPool({vw_name},
-                                                                 {VirtualWarehouseType::Write, VirtualWarehouseType::Default});
-        if (!worker_pool || worker_pool->empty())
-            throw Exception("Init worker pool #" + vw_name + " failed, pls check it", ErrorCodes::LOGICAL_ERROR);
+        /// May throw exception: VIRTUAL_WAREHOUSE_NOT_FOUND
+        vw_handle = global_context->getVirtualWarehousePool().get(vw_name);
     }
 
     /// Random mode:
@@ -49,7 +44,7 @@ namespace DB
     CnchWorkerClientPtr KafkaConsumerSchedulerRandom::selectWorkerNode(const String & /* key */, const size_t /* index */)
     {
         initOrUpdateWorkerPool();
-        return worker_pool->get();
+        return vw_handle->getWorker();
     }
 
     /// Hash mode:
@@ -62,7 +57,7 @@ namespace DB
     CnchWorkerClientPtr KafkaConsumerSchedulerHash::selectWorkerNode(const String &key, const size_t /* index */)
     {
         initOrUpdateWorkerPool();
-        return worker_pool->getByHashRing(key);
+        return vw_handle->getWorkerByHash(key);
     }
 
     bool KafkaConsumerSchedulerHash::shouldReschedule(const CnchWorkerClientPtr current_worker, const String & key, const size_t index)
@@ -92,7 +87,7 @@ namespace DB
     {
         IKafkaConsumerScheduler::initOrUpdateWorkerPool();
 
-        auto new_clients = worker_pool->getAll();
+        auto new_clients = vw_handle->getAllWorkers();
         std::unordered_map<CnchWorkerClientPtr, size_t> new_clients_map;
         std::priority_queue<client_status> new_clients_queue;
 
@@ -131,7 +126,7 @@ namespace DB
 
             clients_status_map.erase(node.client_ptr);
         }
-        throw Exception("No available service for " + worker_pool->getServiceName(), ErrorCodes::LOGICAL_ERROR);
+        throw Exception("No available workers for scheduling Kafka consumer, vw: " + vw_name, ErrorCodes::LOGICAL_ERROR);
     }
 
     bool KafkaConsumerSchedulerLeastConsumers::shouldReschedule(const CnchWorkerClientPtr current_worker, const String & /* key */, const size_t index)

--- a/src/Storages/Kafka/CnchKafkaConsumerScheduler.cpp
+++ b/src/Storages/Kafka/CnchKafkaConsumerScheduler.cpp
@@ -20,6 +20,11 @@
 
 namespace DB
 {
+    namespace ErrorCodes
+    {
+        extern const int RESOURCE_MANAGER_NO_AVAILABLE_WORKER;
+    }
+
     IKafkaConsumerScheduler::IKafkaConsumerScheduler(const String &vw_name_, const KafkaConsumerScheduleMode schedule_mode_, ContextPtr context_)
         : vw_name(std::move(vw_name_)), schedule_mode(schedule_mode_), global_context(context_->getGlobalContext()),
         log(&Poco::Logger::get("KafkaConsumer" + String(getScheduleModeName()) + "Scheduler"))
@@ -126,7 +131,7 @@ namespace DB
 
             clients_status_map.erase(node.client_ptr);
         }
-        throw Exception("No available workers for scheduling Kafka consumer, vw: " + vw_name, ErrorCodes::LOGICAL_ERROR);
+        throw Exception("No available workers for scheduling Kafka consumer, vw: " + vw_name, ErrorCodes::RESOURCE_MANAGER_NO_AVAILABLE_WORKER);
     }
 
     bool KafkaConsumerSchedulerLeastConsumers::shouldReschedule(const CnchWorkerClientPtr current_worker, const String & /* key */, const size_t index)

--- a/src/Storages/Kafka/CnchKafkaConsumerScheduler.h
+++ b/src/Storages/Kafka/CnchKafkaConsumerScheduler.h
@@ -19,6 +19,7 @@
 
 #include <CloudServices/CnchWorkerClientPools.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/VirtualWarehousePool.h>
 
 namespace DB
 {
@@ -72,8 +73,8 @@ protected:
 
     virtual void initOrUpdateWorkerPool();
 
-    CnchWorkerClientPoolPtr worker_pool;
     String vw_name;
+    VirtualWarehouseHandle vw_handle;
     KafkaConsumerScheduleMode schedule_mode;
     ContextPtr global_context;
     Poco::Logger * log;

--- a/src/TableFunctions/TableFunctionCnch.cpp
+++ b/src/TableFunctions/TableFunctionCnch.cpp
@@ -38,10 +38,7 @@ namespace ErrorCodes
 std::shared_ptr<Cluster> mockVWCluster(const Context & context, const String & vw_name)
 {
     auto vw_handle = context.getVirtualWarehousePool().get(vw_name);
-    auto value = context.getSettingsRef().vw_schedule_algo.value;
-    auto algo = ResourceManagement::toVWScheduleAlgo(&value[0]);
-    auto wg_handle = vw_handle->pickWorkerGroup(algo);
-    const auto & worker_clients = wg_handle->getWorkerClients();
+    const auto worker_clients = vw_handle->getAllWorkers();
 
     auto user_password = context.getCnchInterserverCredentials();
 

--- a/src/TableFunctions/TableFunctionCnch.cpp
+++ b/src/TableFunctions/TableFunctionCnch.cpp
@@ -20,6 +20,7 @@
 #include <Storages/getStructureOfRemoteTable.h>
 #include <Storages/StorageDistributed.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/VirtualWarehousePool.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTIdentifier.h>
 #include <TableFunctions/TableFunctionFactory.h>
@@ -36,22 +37,11 @@ namespace ErrorCodes
 
 std::shared_ptr<Cluster> mockVWCluster(const Context & context, const String & vw_name)
 {
-    auto & worker_pools = context.getCnchWorkerClientPools();
-
-    CnchWorkerClientPoolPtr vw_client_pool = worker_pools.getPool(vw_name);
-    if (!vw_client_pool)
-        throw Exception("vw doesn't exist, vw name:" + vw_name, ErrorCodes::BAD_ARGUMENTS);
-
-    std::vector<std::shared_ptr<CnchWorkerClient>> worker_clients;
-    try
-    {
-        worker_clients = vw_client_pool->getAll();
-    }
-    catch(const Exception & e)
-    {
-        throw Exception("Get worker clients for vw " + vw_name + " failed. Got exception "
-             + e.displayText(), e.code());
-    }
+    auto vw_handle = context.getVirtualWarehousePool().get(vw_name);
+    auto value = context.getSettingsRef().vw_schedule_algo.value;
+    auto algo = ResourceManagement::toVWScheduleAlgo(&value[0]);
+    auto wg_handle = vw_handle->pickWorkerGroup(algo);
+    auto & worker_clients = wg_handle->getWorkerClients();
 
     auto user_password = context.getCnchInterserverCredentials();
 

--- a/src/TableFunctions/TableFunctionCnch.cpp
+++ b/src/TableFunctions/TableFunctionCnch.cpp
@@ -41,12 +41,12 @@ std::shared_ptr<Cluster> mockVWCluster(const Context & context, const String & v
     auto value = context.getSettingsRef().vw_schedule_algo.value;
     auto algo = ResourceManagement::toVWScheduleAlgo(&value[0]);
     auto wg_handle = vw_handle->pickWorkerGroup(algo);
-    auto & worker_clients = wg_handle->getWorkerClients();
+    const auto & worker_clients = wg_handle->getWorkerClients();
 
     auto user_password = context.getCnchInterserverCredentials();
 
     std::vector<Cluster::Addresses> addresses;
-    for (auto & client : worker_clients)
+    for (const auto & client : worker_clients)
     {
         if (client)
         {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [placeholder]

Changelog category (leave one):
- Improvement


Detailed description / Documentation draft:
- Use VirtualWarehousePool as the only way for getting workers.
- Fix divide zero error for ResourceTracker


If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ByConity Documentation](https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md) guide first.

