### PR TITLE
Add query-level storage cache

### DIFF
--- a/src/Databases/DatabaseCnch.h
+++ b/src/Databases/DatabaseCnch.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <Common/Exception.h>
 #include <Common/escapeForFileName.h>
 #include <Common/quoteString.h>
@@ -23,6 +24,7 @@
 #include <Storages/IStorage.h>
 #include <Transaction/TxnTimestamp.h>
 #include <Common/ErrorCodes.h>
+#include "Storages/IStorage_fwd.h"
 #include <Interpreters/Context_fwd.h>
 
 namespace DB
@@ -84,6 +86,10 @@ protected:
 
 private:
     const UUID db_uuid;
+    /// local storage cache, mapping from name->storage, mainly for select query
+    /// Work under an assumptions that database was re-created for each query
+    mutable std::unordered_map<String, StoragePtr> cache;
+    mutable std::shared_mutex cache_mutex;
     Poco::Logger * log;
 };
 

--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -282,38 +282,6 @@ DatabaseAndTable DatabaseCatalog::getTableImpl(
         }
     }
 
-    if (table_id.hasUUID())
-    {
-        /// Shortcut for tables which have persistent UUID
-        auto db_and_table = tryGetByUUID(table_id.uuid, context_);
-        if (!db_and_table.first || !db_and_table.second)
-        {
-            assert(!db_and_table.first && !db_and_table.second);
-            if (exception)
-                exception->emplace(ErrorCodes::UNKNOWN_TABLE, "Table {} with uuid: {} doesn't exist", table_id.getNameForLogs(),
-                    UUIDHelpers::UUIDToString(table_id.uuid));
-            return {};
-        }
-
-#if USE_LIBPQXX
-        if (!context_->isInternalQuery() && (db_and_table.first->getEngineName() == "MaterializedPostgreSQL"))
-        {
-            db_and_table.second = std::make_shared<StorageMaterializedPostgreSQL>(std::move(db_and_table.second), getContext());
-        }
-#endif
-
-#if USE_MYSQL
-        /// It's definitely not the best place for this logic, but behaviour must be consistent with DatabaseMaterializeMySQL::tryGetTable(...)
-        if (db_and_table.first->getEngineName() == "MaterializeMySQL")
-        {
-            if (!MaterializeMySQLSyncThread::isMySQLSyncThread())
-                db_and_table.second = std::make_shared<StorageMaterializeMySQL>(std::move(db_and_table.second), db_and_table.first.get());
-        }
-#endif
-        return db_and_table;
-    }
-
-
     if (table_id.database_name == TEMPORARY_DATABASE)
     {
         /// For temporary tables UUIDs are set in Context::resolveStorageID(...).


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [placeholder]

Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Remove short-cut to get table via UUID in database catalog, it cannot use storage cache and has bad effect on performance
- Add query-level storage cache (in DatabaseCnch) to reduce calls to kv 


Detailed description / Documentation draft:

...


If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ByConity Documentation](https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md) guide first.

