### PR TITLE
WIP optimize CBO overhead 

### DIFF
--- a/src/Common/serverLocality.cpp
+++ b/src/Common/serverLocality.cpp
@@ -43,7 +43,7 @@ bool isLocalServer(const std::string & target, const std::string & port)
 
         const std::string target_ip = DB::DNSResolver::instance().resolveHost(target_host).toString();
 
-        if ((target_ip == "127.0.0.1") || (target_ip == "::1") || (target_ip == getIPOrFQDNOrHostName()) || (target_ip == DB::getHostIPFromEnv()))
+        if ((target_ip == "127.0.0.1") || (target_ip == "::1") || (target_ip == DB::getHostIPFromEnv()) || (target_ip == getIPOrFQDNOrHostName()))
         {
             return true;
         }

--- a/src/Interpreters/SegmentScheduler.cpp
+++ b/src/Interpreters/SegmentScheduler.cpp
@@ -318,7 +318,7 @@ void SegmentScheduler::buildDAGGraph(PlanSegmentTree * plan_segments_ptr, std::s
             graph_ptr->sources.emplace_back(plan_segment_ptr->getPlanSegmentId());
         }
         // source
-        if (plan_segment_ptr->getPlanSegmentInputs().size() >= 1)
+        if (!plan_segment_ptr->getPlanSegmentInputs().empty())
         {
             bool all_tables = true;
             for (const auto & input : plan_segment_ptr->getPlanSegmentInputs())
@@ -373,7 +373,7 @@ void SegmentScheduler::buildDAGGraph(PlanSegmentTree * plan_segments_ptr, std::s
     {
         if (!it->second->getPlanSegmentInputs().empty())
         {
-            for (auto plan_segment_input_ptr : it->second->getPlanSegmentInputs())
+            for (const auto & plan_segment_input_ptr : it->second->getPlanSegmentInputs())
             {
                 // only check when input is from an another exchange
                 if (plan_segment_input_ptr->getPlanSegmentType() != PlanSegmentType::EXCHANGE)

--- a/src/Optimizer/CardinalityEstimate/AssignUniqueIdEstimator.cpp
+++ b/src/Optimizer/CardinalityEstimate/AssignUniqueIdEstimator.cpp
@@ -30,11 +30,11 @@ PlanNodeStatisticsPtr AssignUniqueIdEstimator::estimate(PlanNodeStatisticsPtr & 
     std::unordered_map<String, SymbolStatisticsPtr> symbol_statistics;
     for (auto & stats : child_stats->getSymbolStatistics())
     {
-        symbol_statistics[stats.first] = stats.second->copy();
+        symbol_statistics.insert_or_assign(stats.first, stats.second->copy());
     }
-    symbol_statistics[unique_symbol] = unique_stats;
+    symbol_statistics.insert_or_assign(unique_symbol, unique_stats);
 
-    auto stats = std::make_shared<PlanNodeStatistics>(child_stats->getRowCount(), symbol_statistics);
+    auto stats = std::make_shared<PlanNodeStatistics>(child_stats->getRowCount(), std::move(symbol_statistics));
     return stats;
 }
 

--- a/src/Optimizer/CardinalityEstimate/CardinalityEstimator.cpp
+++ b/src/Optimizer/CardinalityEstimate/CardinalityEstimator.cpp
@@ -267,9 +267,9 @@ PlanNodeStatisticsPtr CardinalityVisitor::visitCTERefStep(const CTERefStep & ste
 
     auto & stats = result.value();
     std::unordered_map<String, SymbolStatisticsPtr> calculated_symbol_statistics;
-    for (auto & item : step.getOutputColumns())
-        calculated_symbol_statistics[item.first] = stats->getSymbolStatistics(item.second);
-    return std::make_shared<PlanNodeStatistics>(stats->getRowCount(), calculated_symbol_statistics);
+    for (const auto & item : step.getOutputColumns())
+        calculated_symbol_statistics.insert_or_assign(item.first, stats->getSymbolStatistics(item.second));
+    return std::make_shared<PlanNodeStatistics>(stats->getRowCount(), std::move(calculated_symbol_statistics));
 }
 
 PlanNodeStatisticsPtr CardinalityVisitor::visitEnforceSingleRowStep(const EnforceSingleRowStep & step, CardinalityContext & context)

--- a/src/Optimizer/CardinalityEstimate/ExchangeEstimator.cpp
+++ b/src/Optimizer/CardinalityEstimate/ExchangeEstimator.cpp
@@ -47,14 +47,14 @@ PlanNodeStatisticsPtr ExchangeEstimator::mapToOutput(
 {
     std::unordered_map<String, SymbolStatisticsPtr> output_symbol_statistics;
 
-    for (auto & symbol : out_to_input)
+    for (const auto & symbol : out_to_input)
     {
-        String output_symbol = symbol.first;
-        auto & input_symbols = symbol.second;
-        output_symbol_statistics[output_symbol] = child_stats->getSymbolStatistics(input_symbols.at(index))->copy();
+        const String & output_symbol = symbol.first;
+        const auto & input_symbols = symbol.second;
+        output_symbol_statistics.insert_or_assign(output_symbol, child_stats->getSymbolStatistics(input_symbols.at(index))->copy());
     }
 
-    return std::make_shared<PlanNodeStatistics>(child_stats->getRowCount(), output_symbol_statistics);
+    return std::make_shared<PlanNodeStatistics>(child_stats->getRowCount(), std::move(output_symbol_statistics));
 }
 
 }

--- a/src/Optimizer/CardinalityEstimate/JoinEstimator.cpp
+++ b/src/Optimizer/CardinalityEstimate/JoinEstimator.cpp
@@ -303,7 +303,7 @@ UInt64 JoinEstimator::computeCardinalityByFKPK(
 
         for (auto & item : fk_stats.getSymbolStatistics())
         {
-            join_output_statistics[item.first] = item.second->copy();
+            join_output_statistics.insert_or_assign(item.first, item.second->copy());
         }
 
         // PK side partial match, adjust statistics;

--- a/src/Optimizer/CardinalityEstimate/PlanNodeStatistics.cpp
+++ b/src/Optimizer/CardinalityEstimate/PlanNodeStatistics.cpp
@@ -26,9 +26,9 @@ PlanNodeStatistics::PlanNodeStatistics(UInt64 row_count_, std::unordered_map<Str
 
 SymbolStatisticsPtr PlanNodeStatistics::getSymbolStatistics(const String & symbol)
 {
-    if (symbol_statistics.contains(symbol))
+    if (auto it = symbol_statistics.find(symbol); it != symbol_statistics.end())
     {
-        return symbol_statistics[symbol];
+        return it->second;
     }
     return SymbolStatistics::UNKNOWN;
 }
@@ -36,7 +36,7 @@ SymbolStatisticsPtr PlanNodeStatistics::getSymbolStatistics(const String & symbo
 UInt64 PlanNodeStatistics::getOutputSizeInBytes() const
 {
     size_t row_size = 0;
-    for (auto & symbols : symbol_statistics)
+    for (const auto & symbols : symbol_statistics)
     {
         if (!symbols.second->isUnknown())
         {
@@ -52,7 +52,7 @@ String PlanNodeStatistics::toString() const
     details << "RowCount: " << row_count << "\\n";
     details << "DataSize: " << std::to_string(getOutputSizeInBytes()) << "\\n";
     details << "Symbol\\n";
-    for (auto & symbol : symbol_statistics)
+    for (const auto & symbol : symbol_statistics)
     {
         details << symbol.first << ": " << symbol.second->getNdv() << ", " << symbol.second->getMin() << ", " << symbol.second->getMax()
                 << ", hist:" << symbol.second->getHistogram().getBuckets().size() << "\\n";
@@ -66,7 +66,7 @@ Poco::JSON::Object::Ptr PlanNodeStatistics::toJson() const
     json->set("rowCont", row_count);
 
     Poco::JSON::Array symbol_statistics_json_array;
-    for (auto & item : symbol_statistics)
+    for (const auto & item : symbol_statistics)
     {
         Poco::JSON::Object::Ptr symbol_statistics_json = new Poco::JSON::Object;
         symbol_statistics_json->set("symbol", item.first);

--- a/src/Optimizer/CardinalityEstimate/PlanNodeStatistics.h
+++ b/src/Optimizer/CardinalityEstimate/PlanNodeStatistics.h
@@ -41,23 +41,21 @@ public:
         std::unordered_map<String, SymbolStatisticsPtr> copy_symbol_statistics;
         for (const auto & item : symbol_statistics)
         {
-            copy_symbol_statistics[item.first] = item.second->copy();
+            copy_symbol_statistics.insert_or_assign(item.first, item.second->copy());
         }
-        return std::make_shared<PlanNodeStatistics>(row_count, symbol_statistics);
+        return std::make_shared<PlanNodeStatistics>(row_count, std::move(copy_symbol_statistics));
     }
 
     PlanNodeStatistics & operator+=(const PlanNodeStatistics & other)
     {
         row_count += other.row_count;
 
-        for (auto & symbols_stats : symbol_statistics)
+        for (auto & it : symbol_statistics)
         {
-            for (auto & other_symbols_stats : other.symbol_statistics)
+            auto jt =  other.symbol_statistics.find(it.first);
+            if (jt != other.symbol_statistics.end())
             {
-                if (symbols_stats.first == other_symbols_stats.first)
-                {
-                    *symbols_stats.second + *other_symbols_stats.second;
-                }
+                *it.second + *jt->second;
             }
         }
         return *this;

--- a/src/Optimizer/CardinalityEstimate/UnionEstimator.cpp
+++ b/src/Optimizer/CardinalityEstimate/UnionEstimator.cpp
@@ -20,7 +20,7 @@ namespace DB
 PlanNodeStatisticsPtr UnionEstimator::estimate(std::vector<PlanNodeStatisticsPtr> & children_stats, const UnionStep & step)
 {
     PlanNodeStatisticsPtr output;
-    auto & out_to_input = step.getOutToInputs();
+    const auto & out_to_input = step.getOutToInputs();
     for (size_t i = 0; i < children_stats.size(); i++)
     {
         if (!children_stats.at(i))
@@ -47,14 +47,12 @@ PlanNodeStatisticsPtr UnionEstimator::mapToOutput(
 {
     std::unordered_map<String, SymbolStatisticsPtr> output_symbol_statistics;
 
-    for (auto & symbol : out_to_input)
+    for (const auto & [k, v] : out_to_input)
     {
-        String output_symbol = symbol.first;
-        auto & input_symbols = symbol.second;
-        output_symbol_statistics[output_symbol] = child_stats.getSymbolStatistics(input_symbols.at(index))->copy();
+        output_symbol_statistics.insert_or_assign(k, child_stats.getSymbolStatistics(v.at(index))->copy());
     }
 
-    return std::make_shared<PlanNodeStatistics>(child_stats.getRowCount(), output_symbol_statistics);
+    return std::make_shared<PlanNodeStatistics>(child_stats.getRowCount(), std::move(output_symbol_statistics));
 }
 
 }

--- a/src/Optimizer/Cascades/CascadesOptimizer.cpp
+++ b/src/Optimizer/Cascades/CascadesOptimizer.cpp
@@ -134,7 +134,7 @@ GroupExprPtr CascadesContext::initMemo(const PlanNodePtr & plan_node)
         {
             queue.push(child);
         }
-        if (auto read_step = dynamic_cast<const CTERefStep *>(node->getStep().get()))
+        if (const auto * read_step = dynamic_cast<const CTERefStep *>(node->getStep().get()))
         {
             if (!memo.containsCTEId(read_step->getId()))
             {

--- a/src/Optimizer/Cascades/Memo.cpp
+++ b/src/Optimizer/Cascades/Memo.cpp
@@ -44,11 +44,9 @@ GroupExprPtr Memo::insertGroupExpr(GroupExprPtr group_expr, CascadesContext & co
     auto it = group_expressions.find(group_expr);
     // duplicate group expression
     if (it != group_expressions.end())
-    {
         return *it;
-    }
-
-    group_expressions.insert(group_expr);
+    else
+        group_expressions.insert(it, group_expr);
 
     // New expression, so try to insert into an existing group or
     // create a new group if none specified

--- a/src/Optimizer/ImplementSetOperation.cpp
+++ b/src/Optimizer/ImplementSetOperation.cpp
@@ -52,6 +52,7 @@ TranslationResult SetOperationNodeTranslator::makeSetContainmentPlanForDistinct(
         group_by_keys.emplace_back(item.name);
 
     AggregateDescriptions aggregates;
+    aggregates.reserve(markers.size());
     for (size_t i = 0; i < markers.size(); i++)
     {
         AggregateDescription aggregate_desc;
@@ -62,7 +63,7 @@ TranslationResult SetOperationNodeTranslator::makeSetContainmentPlanForDistinct(
         AggregateFunctionProperties properties;
         aggregate_desc.function = AggregateFunctionFactory::instance().get("sum", types, params, properties);
 
-        aggregates.push_back(aggregate_desc);
+        aggregates.emplace_back(aggregate_desc);
     }
 
     auto agg_step = std::make_shared<AggregatingStep>(union_node->getStep()->getOutputStream(), group_by_keys, aggregates, GroupingSetsParamsList{}, true, GroupingDescriptions{}, false, false);
@@ -75,6 +76,7 @@ TranslationResult SetOperationNodeTranslator::makeSetContainmentPlanForDistinct(
 PlanNodePtr SetOperationNodeTranslator::unionNodes(const PlanNodes & children, const NamesAndTypes cols)
 {
     DataStreams input_stream;
+    input_stream.reserve(children.size());
     for (const auto & item : children)
         input_stream.emplace_back(item->getStep()->getOutputStream());
     DataStream output;

--- a/src/Optimizer/ImplementSetOperation.h
+++ b/src/Optimizer/ImplementSetOperation.h
@@ -102,9 +102,9 @@ private:
             new_name_to_type[markers[i]] = std::make_shared<DataTypeUInt8>();
         }
 
-        auto expression_step = std::make_shared<ProjectionStep>(output_stream, assignments, new_name_to_type);
+        auto expression_step = std::make_shared<ProjectionStep>(output_stream, std::move(assignments), std::move(new_name_to_type));
         PlanNodes children{source};
-        PlanNodePtr expr_node = std::make_shared<ProjectionNode>(context.nextNodeId(), std::move(expression_step), children);
+        PlanNodePtr expr_node = std::make_shared<ProjectionNode>(context.nextNodeId(), std::move(expression_step), std::move(children));
         return expr_node;
     }
 

--- a/src/Optimizer/JoinGraph.cpp
+++ b/src/Optimizer/JoinGraph.cpp
@@ -52,6 +52,7 @@ JoinGraph JoinGraph::withJoinGraph(
             throw Exception("Node appeared in two JoinGraphs, id : " + std::to_string(node->getId()), ErrorCodes::LOGICAL_ERROR);
 
     std::vector<PlanNodePtr> nodes_merged;
+    nodes_merged.reserve(nodes.size() + other.nodes.size());
     nodes_merged.insert(nodes_merged.end(), nodes.begin(), nodes.end());
     nodes_merged.insert(nodes_merged.end(), other.nodes.begin(), other.nodes.end());
 
@@ -60,6 +61,7 @@ JoinGraph JoinGraph::withJoinGraph(
     edges_merged.insert(other.edges.begin(), other.edges.end());
 
     std::vector<ConstASTPtr> filters_merged;
+    filters_merged.reserve(filters_merged.size() + other.filter.size());
     filters_merged.insert(filters_merged.end(), filter.begin(), filter.end());
     filters_merged.insert(filters_merged.end(), other.filter.begin(), other.filter.end());
 
@@ -193,9 +195,9 @@ JoinGraph JoinGraphVisitor::visitProjectionNode(ProjectionNode & node, NameSet &
 {
     if (ignore_columns_not_join_condition)
     {
-        auto step = dynamic_cast<const ProjectionStep *>(node.getStep().get());
+        const auto * step = dynamic_cast<const ProjectionStep *>(node.getStep().get());
         bool contains_required_columns = false;
-        for (auto & assigment : step->getAssignments())
+        for (const auto & assigment : step->getAssignments())
         {
             if (Utils::isIdentity(assigment))
                 continue;

--- a/src/Optimizer/PredicateUtils.cpp
+++ b/src/Optimizer/PredicateUtils.cpp
@@ -151,6 +151,7 @@ ConstASTPtr PredicateUtils::extractCommonPredicates(ConstASTPtr predicate, Conte
         std::vector<std::pair<ConstASTPtr, String>> uncorrelated_map = removeAll(pairs, common_predicates);
 
         std::vector<ConstASTPtr> uncorrelate_predicates;
+        uncorrelate_predicates.reserve(uncorrelated_map.size());
         for (auto & uncorrelated : uncorrelated_map)
         {
             uncorrelate_predicates.emplace_back(uncorrelated.first);
@@ -301,7 +302,7 @@ ASTPtr PredicateUtils::combineDisjunctsWithDefault(const std::vector<ConstASTPtr
         return predicates[0]->clone();
 
     ASTs args;
-    for (auto & arg : predicates)
+    for (const auto & arg : predicates)
     {
         if (isTruePredicate(arg))
             return PredicateConst::TRUE_VALUE;
@@ -611,11 +612,11 @@ PredicateUtils::extractEqualPredicates(const std::vector<ConstASTPtr> & predicat
     std::vector<std::pair<ConstASTPtr, ConstASTPtr>> equal_predicates;
     std::vector<ConstASTPtr> other_predicates;
 
-    for (auto & predicate : predicates)
+    for (const auto & predicate : predicates)
     {
         for (auto & filter : PredicateUtils::extractConjuncts(predicate))
         {
-            auto function = filter->as<ASTFunction>();
+            const auto * function = filter->as<ASTFunction>();
             if (function && function->name == "equals")
             {
                 if (function->children.size() == 2 && function->children[0]->getType() == ASTType::ASTIdentifier

--- a/src/Optimizer/Property/PropertyEnforcer.cpp
+++ b/src/Optimizer/Property/PropertyEnforcer.cpp
@@ -73,31 +73,26 @@ QueryPlanStepPtr PropertyEnforcer::enforceNodePartitioning(
 {
     const auto & output_stream = step->getOutputStream();
     DataStreams streams{output_stream};
-    Partitioning partitioning = required.getNodePartitioning();
+    const Partitioning & partitioning = required.getNodePartitioning();
 
     // if the stream is ordered, we need keep order when exchange data.
     bool keep_order = context.getSettingsRef().enable_shuffle_with_order;
 
     if (partitioning.getPartitioningHandle() == Partitioning::Handle::SINGLE)
     {
-        QueryPlanStepPtr step_ptr = std::make_unique<ExchangeStep>(streams, ExchangeMode::GATHER, partitioning, keep_order);
-        return step_ptr;
+        return std::make_unique<ExchangeStep>(std::move(streams), ExchangeMode::GATHER, partitioning, keep_order);
     }
     if (partitioning.getPartitioningHandle() == Partitioning::Handle::FIXED_HASH)
     {
-        QueryPlanStepPtr step_ptr = std::make_unique<ExchangeStep>(streams, ExchangeMode::REPARTITION, partitioning, keep_order);
-        return step_ptr;
+        return std::make_unique<ExchangeStep>(std::move(streams), ExchangeMode::REPARTITION, partitioning, keep_order);
     }
     if (partitioning.getPartitioningHandle() == Partitioning::Handle::FIXED_BROADCAST)
     {
-        QueryPlanStepPtr step_ptr = std::make_unique<ExchangeStep>(streams, ExchangeMode::BROADCAST, partitioning, keep_order);
-        return step_ptr;
+        return std::make_unique<ExchangeStep>(std::move(streams), ExchangeMode::BROADCAST, partitioning, keep_order);
     }
     if (partitioning.getPartitioningHandle() == Partitioning::Handle::FIXED_ARBITRARY)
     {
-        QueryPlanStepPtr step_ptr
-            = std::make_unique<ExchangeStep>(streams, ExchangeMode::LOCAL_NO_NEED_REPARTITION, partitioning, keep_order);
-        return step_ptr;
+        return std::make_unique<ExchangeStep>(std::move(streams), ExchangeMode::LOCAL_NO_NEED_REPARTITION, partitioning, keep_order);
     }
     if (partitioning.getPartitioningHandle() == Partitioning::Handle::ARBITRARY)
     {
@@ -115,8 +110,7 @@ PropertyEnforcer::enforceStreamPartitioning(ConstQueryPlanStepPtr step, const Pr
 
     if (required.getStreamPartitioning().getPartitioningHandle() == Partitioning::Handle::SINGLE)
     {
-        QueryPlanStepPtr step_ptr = std::make_unique<UnionStep>(streams, 0, true);
-        return step_ptr;
+        return std::make_unique<UnionStep>(std::move(streams), 0, true);
     }
     throw Exception("Property Enforce error", ErrorCodes::ILLEGAL_ENFORCE);
 }

--- a/src/Optimizer/Rewriter/AddDynamicFilters.cpp
+++ b/src/Optimizer/Rewriter/AddDynamicFilters.cpp
@@ -230,6 +230,7 @@ PlanWithScanRows AddDynamicFilters::DynamicFilterPredicatesRewriter::visitPlanNo
     PlanNodes children;
     size_t total_rows = 0;
     DataStreams inputs;
+    inputs.reserve(plan.getChildren().size());
     for (auto & child : plan.getChildren())
     {
         auto result = VisitorUtil::accept(*child, *this, context);
@@ -241,7 +242,7 @@ PlanWithScanRows AddDynamicFilters::DynamicFilterPredicatesRewriter::visitPlanNo
     new_step->setInputStreams(inputs);
     plan.setStep(new_step);
 
-    plan.replaceChildren(children);
+    plan.replaceChildren(std::move(children));
     return PlanWithScanRows{plan.shared_from_this(), total_rows};
 }
 

--- a/src/Optimizer/Rewriter/AddDynamicFilters.cpp
+++ b/src/Optimizer/Rewriter/AddDynamicFilters.cpp
@@ -457,7 +457,7 @@ PlanNodePtr AddDynamicFilters::RemoveUnusedDynamicFilterRewriter::visitProjectio
         project_step->getAssignments(),
         project_step->getNameToType(),
         project_step->isFinalProject(),
-        dynamic_filters);
+        std::move(dynamic_filters));
 
     return PlanNodeBase::createPlanNode(node.getId(), new_project_step, PlanNodes{result}, node.getStatistics());
 }

--- a/src/Optimizer/Rewriter/ColumnPruning.cpp
+++ b/src/Optimizer/Rewriter/ColumnPruning.cpp
@@ -153,7 +153,7 @@ PlanNodePtr ColumnPruningVisitor::visitProjectionNode(ProjectionNode & node, Nam
         return child;
 
     auto expr_step = std::make_shared<ProjectionStep>(
-        child->getStep()->getOutputStream(), assignments, name_to_type, step->isFinalProject(), step->getDynamicFilters());
+        child->getStep()->getOutputStream(), std::move(assignments), std::move(name_to_type), step->isFinalProject(), step->getDynamicFilters());
     PlanNodes children{child};
     auto expr_node = ProjectionNode::createPlanNode(context->nextNodeId(), std::move(expr_step), children, node.getStatistics());
     return expr_node;

--- a/src/Optimizer/Rewriter/MaterializedViewRewriter.cpp
+++ b/src/Optimizer/Rewriter/MaterializedViewRewriter.cpp
@@ -1138,7 +1138,7 @@ protected:
         // output projection
         plan = PlanNodeBase::createPlanNode(
             context->nextNodeId(),
-            std::make_shared<ProjectionStep>(plan->getCurrentDataStream(), rewrite_assignments, candidate.name_to_type),
+            std::make_shared<ProjectionStep>(plan->getCurrentDataStream(), std::move(rewrite_assignments), candidate.name_to_type),
             {plan});
         return plan;
     }
@@ -1224,15 +1224,15 @@ protected:
             if (!Utils::isIdentity(arguments))
                 plan = PlanNodeBase::createPlanNode(
                     context->nextNodeId(),
-                    std::make_shared<ProjectionStep>(plan->getCurrentDataStream(), arguments, arguments_types),
+                    std::make_shared<ProjectionStep>(plan->getCurrentDataStream(), std::move(arguments), std::move(arguments_types)),
                     {plan});
 
             plan = PlanNodeBase::createPlanNode(
                 context->nextNodeId(),
-                std::make_shared<AggregatingStep>(plan->getCurrentDataStream(), keys, agg_rewriter.aggregates, GroupingSetsParamsList{}, true, GroupingDescriptions{}, false, false),
+                std::make_shared<AggregatingStep>(plan->getCurrentDataStream(), std::move(keys), agg_rewriter.aggregates, GroupingSetsParamsList{}, true, GroupingDescriptions{}, false, false),
                 {plan});
         }
-        return std::make_pair(plan, rewrite_arguments);
+        return std::make_pair(std::move(plan), std::move(rewrite_arguments));
     }
 
 private:

--- a/src/Optimizer/Rule/Rewrite/InlineProjections.cpp
+++ b/src/Optimizer/Rule/Rewrite/InlineProjections.cpp
@@ -179,7 +179,7 @@ std::set<String> InlineProjections::extractInliningTargets(ProjectionNode * pare
     const auto & child_step = *child->getStep();
 
     std::unordered_map<String, UInt32> dependencies;
-    for (auto & assignment : parent_step.getAssignments())
+    for (const auto & assignment : parent_step.getAssignments())
     {
         auto expr = assignment.second;
         std::set<std::string> symbols = SymbolsExtractor::extract(expr);
@@ -204,7 +204,7 @@ std::set<String> InlineProjections::extractInliningTargets(ProjectionNode * pare
         }
     }
 
-    std::set<String> singletons;
+    std::set<String> & singletons = constants;
     for (auto & dependency : dependencies)
     {
         const auto & symbol = dependency.first;
@@ -215,7 +215,7 @@ std::set<String> InlineProjections::extractInliningTargets(ProjectionNode * pare
             continue;
         }
 
-        auto& expr = child_step.getAssignments().at(symbol);
+        const auto & expr = child_step.getAssignments().at(symbol);
 
         if(!ExpressionDeterminism::isDeterministic(expr, context)) {
             continue;
@@ -237,7 +237,6 @@ std::set<String> InlineProjections::extractInliningTargets(ProjectionNode * pare
             singletons.emplace(symbol);
         }
     }
-    singletons.insert(constants.begin(), constants.end());
 
     // inline all if remaining are not used or identity.
     std::set<String> identities_or_not_used;
@@ -279,7 +278,7 @@ PatternPtr InlineProjectionIntoJoin::getPattern() const
 
 TransformResult InlineProjectionIntoJoin::transformImpl(PlanNodePtr node, const Captures &, RuleContext & context)
 {
-    auto old_join_node = dynamic_cast<JoinNode *>(node.get());
+    auto * old_join_node = dynamic_cast<JoinNode *>(node.get());
     if (!old_join_node)
         return {};
 

--- a/src/Parsers/ASTSerDerHelper.cpp
+++ b/src/Parsers/ASTSerDerHelper.cpp
@@ -117,7 +117,7 @@ void serializeAST(const IAST & ast, WriteBuffer & buf)
     ast.serialize(buf);
 }
 
-void serializeAST(const ASTPtr & ast, WriteBuffer & buf)
+void serializeAST(const ConstASTPtr & ast, WriteBuffer & buf)
 {
     if (ast)
     {

--- a/src/Parsers/ASTSerDerHelper.h
+++ b/src/Parsers/ASTSerDerHelper.h
@@ -25,7 +25,7 @@ namespace DB
 
 ASTPtr createByASTType(ASTType type, ReadBuffer & buf);
 
-void serializeAST(const ASTPtr & ast, WriteBuffer & buf);
+void serializeAST(const ConstASTPtr & ast, WriteBuffer & buf);
 
 void serializeAST(const IAST & ast, WriteBuffer & buf);
 

--- a/src/QueryPlan/ExchangeStep.h
+++ b/src/QueryPlan/ExchangeStep.h
@@ -50,6 +50,7 @@ public:
     Block getHeader() const { return getOutputStream().header; }
     std::shared_ptr<IQueryPlanStep> copy(ContextPtr ptr) const override;
     void setInputStreams(const DataStreams & input_streams_) override;
+    void setInputStreams(DataStreams && input_streams_);
 
 private:
     ExchangeMode exchange_type = ExchangeMode::UNKNOWN;

--- a/src/QueryPlan/JoinStep.cpp
+++ b/src/QueryPlan/JoinStep.cpp
@@ -265,7 +265,7 @@ void JoinStep::serialize(WriteBuffer & buf, bool with_output) const
         writeVectorBinary(left_keys, buf);
         writeVectorBinary(right_keys, buf);
 
-        serializeAST(filter->clone(), buf);
+        serializeAST(filter, buf);
         writeBinary(has_using, buf);
 
         writeBinary(require_right_keys.has_value(), buf);

--- a/src/QueryPlan/ReadFromPreparedSource.h
+++ b/src/QueryPlan/ReadFromPreparedSource.h
@@ -50,7 +50,7 @@ public:
     ReadFromStorageStep(Pipe pipe_, String storage_name)
         : ReadFromPreparedSource(std::move(pipe_))
     {
-        setStepDescription(storage_name);
+        setStepDescription(std::move(storage_name));
     }
 
     String getName() const override { return "ReadFromStorage"; }

--- a/src/QueryPlan/TableScanStep.cpp
+++ b/src/QueryPlan/TableScanStep.cpp
@@ -117,7 +117,7 @@ TableScanStep::TableScanStep(
     , max_block_size(max_block_size_)
 {
     log = &Poco::Logger::get("TableScanStep");
-
+    column_names.reserve(column_alias.size());
     for (auto & item : column_alias)
     {
         column_names.emplace_back(item.first);

--- a/src/QueryPlan/UnionStep.cpp
+++ b/src/QueryPlan/UnionStep.cpp
@@ -49,7 +49,7 @@ UnionStep::UnionStep(
     std::unordered_map<String, std::vector<String>> output_to_inputs_,
     size_t max_threads_,
     bool local_)
-    : SetOperationStep(input_streams_, output_stream_, output_to_inputs_), max_threads(max_threads_), local(local_)
+    : SetOperationStep(std::move(input_streams_), std::move(output_stream_), std::move(output_to_inputs_)), max_threads(max_threads_), local(local_)
 {
     header = Block();
     for (auto & item : output_stream->header)

--- a/src/QueryPlan/ValuesStep.cpp
+++ b/src/QueryPlan/ValuesStep.cpp
@@ -22,7 +22,7 @@
 
 namespace DB
 {
-ValuesStep::ValuesStep(Block header, Fields fields_, size_t rows_) : ISourceStep(DataStream{.header = header}), fields(fields_), rows(rows_)
+ValuesStep::ValuesStep(Block header, Fields fields_, size_t rows_) : ISourceStep(DataStream{.header = std::move(header)}), fields(std::move(fields_)), rows(rows_)
 {
 }
 

--- a/src/Statistics/StatisticsCollector.cpp
+++ b/src/Statistics/StatisticsCollector.cpp
@@ -93,7 +93,7 @@ void StatisticsCollector::readFromCatalogImpl(const ColumnDescVector & cols_desc
     }
 
     table_stats.readFromCollection(data.table_stats);
-    for (auto & [name, type] : cols_desc)
+    for (const auto & [name, type] : cols_desc)
     {
         if (!data.column_stats.count(name))
         {
@@ -118,7 +118,7 @@ std::optional<PlanNodeStatisticsPtr> StatisticsCollector::toPlanNodeStatistics()
     auto table_row_count = table_stats.basic->getRowCount();
     result->updateRowCount(table_row_count);
     // whether to construct single bucket histogram from min/max if there is no histogram
-    for (auto & [col, stats] : columns_stats)
+    for (const auto & [col, stats] : columns_stats)
     {
         auto symbol = std::make_shared<SymbolStatistics>();
 

--- a/src/Statistics/StatsNdvBucketsResultImpl.cpp
+++ b/src/Statistics/StatsNdvBucketsResultImpl.cpp
@@ -62,11 +62,11 @@ String StatsNdvBucketsResultImpl<T>::serialize() const
     Protos::StatsNdvBucketsResult pb;
     pb.set_bounds_blob(bounds_.serialize());
 
-    for (auto & count : counts_)
+    for (const auto & count : counts_)
     {
         pb.add_counts(count);
     }
-    for (auto & ndv : ndvs_)
+    for (const auto & ndv : ndvs_)
     {
         pb.add_ndvs(ndv);
     }
@@ -81,14 +81,14 @@ String StatsNdvBucketsResultImpl<T>::serializeToJson() const
     Poco::JSON::Parser parser;
     ptr_json->set("bounds_blob", parser.parse(bounds_.serializeToJson()));
     Poco::JSON::Array array_counts;
-    for (auto & count : counts_)
+    for (const auto & count : counts_)
     {
         array_counts.add(int64_t(count));
     }
     ptr_json->set("counts", Poco::Dynamic::Var(array_counts));
 
     Poco::JSON::Array array_ndvs;
-    for (auto & ndv : ndvs_)
+    for (const auto & ndv : ndvs_)
     {
         array_ndvs.add(double(ndv));
     }
@@ -181,7 +181,6 @@ template <typename T>
 void StatsNdvBucketsResultImpl<T>::writeSymbolStatistics(SymbolStatistics & symbol)
 {
     checkValid();
-    Buckets buckets;
     for (size_t i = 0; i < numBuckets(); ++i)
     {
         auto lb = static_cast<double>(bounds_[i]);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [placeholder]

Changelog category (leave one):
- Performance Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Optimize CBO overhead on server

C++ specific optimizations (move constructor, avoid copy, remove std::unordered_map::operator[]...). 
Current stages can reduce CBO overhead on server from second-level to 100-200ms for complex queries (e.g. query 72) by improve CardinalityEstimator.
Continue working on all CBO-related modules.


Detailed description / Documentation draft:

...


If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ByConity Documentation](https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md) guide first.

