### PR TITLE
support krb5 for hdfs

### DIFF
--- a/contrib/libhdfs3-open-cmake/CMakeLists.txt
+++ b/contrib/libhdfs3-open-cmake/CMakeLists.txt
@@ -7,7 +7,15 @@ if (NOT USE_INTERNAL_PROTOBUF_LIBRARY)
     endif ()
 endif()
 
-SET(WITH_KERBEROS false)
+if (${USE_KRB5})
+    SET(WITH_KERBEROS 1)
+else ()
+    SET(WITH_KERBEROS 0)
+endif()
+
+message(STATUS "Using hdfs3 whith KRB5 ${WITH_KERBEROS}")
+
+
 SET(WITH_CURL false)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_POCO_LOGGER")
 
@@ -25,10 +33,6 @@ include(Platform)
 include(Options)
 
 # prefer shared libraries
-if (WITH_KERBEROS)
-    find_package(KERBEROS REQUIRED)
-endif()
-
 if (WITH_CURL)
     find_package(CURL REQUIRED)
 endif()
@@ -75,7 +79,7 @@ target_include_directories(hdfs3 PRIVATE ${HDFS3_ROOT_DIR}/contrib)
 
 target_include_directories(hdfs3 PRIVATE ${LIBGSASL_INCLUDE_DIR})
 if (WITH_KERBEROS)
-    target_include_directories(hdfs3 PRIVATE ${KERBEROS_INCLUDE_DIRS})
+    target_include_directories(hdfs3 PRIVATE ${KRB5_INCLUDE_DIR})
 endif()
 
 if (WITH_CURL)
@@ -87,7 +91,7 @@ target_include_directories(hdfs3 PRIVATE ${LIBXML2_INCLUDE_DIR})
 
 target_link_libraries(hdfs3 ${LIBGSASL_LIBRARY})
 if (WITH_KERBEROS)
-    target_link_libraries(hdfs3 ${KERBEROS_LIBRARIES})
+    target_link_libraries(hdfs3 ${KRB5_LIBRARY})
 endif()
 
 if (WITH_CURL)

--- a/src/Access/CMakeLists.txt
+++ b/src/Access/CMakeLists.txt
@@ -1,0 +1,3 @@
+if (ENABLE_EXAMPLES)
+    add_subdirectory(examples)
+endif()

--- a/src/Access/KerberosInit.cpp
+++ b/src/Access/KerberosInit.cpp
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2016-2023 ClickHouse, Inc.
+ * Copyright 2023 Bytedance Ltd. and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/*
+ * This file may have been modified by Bytedance Ltd. and/or its affiliates (“ Bytedance's Modifications”).
+ * All Bytedance's Modifications are Copyright (2023) Bytedance Ltd. and/or its affiliates.
+ */
+
+#include <Access/KerberosInit.h>
+#include <common/types.h>
+#include <common/logger_useful.h>
+#include <Common/Exception.h>
+#include <Poco/Logger.h>
+#include <filesystem>
+#include <boost/core/noncopyable.hpp>
+#include <fmt/format.h>
+#if USE_KRB5
+#include <krb5.h>
+#include <mutex>
+
+using namespace DB;
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int KERBEROS_ERROR;
+}
+}
+
+namespace
+{
+struct K5Data
+{
+    krb5_context ctx;
+    krb5_ccache out_cc;
+    krb5_principal me;
+    char * name;
+    krb5_boolean switch_to_cache;
+};
+
+/**
+ * This class implements programmatic implementation of kinit.
+ */
+class KerberosInit : boost::noncopyable
+{
+public:
+    void init(const String & keytab_file, const String & principal, const String & cache_name = "");
+    ~KerberosInit();
+private:
+    struct K5Data k5 {};
+    krb5_ccache defcache = nullptr;
+    krb5_get_init_creds_opt * options = nullptr;
+    // Credentials structure including ticket, session key, and lifetime info.
+    krb5_creds my_creds;
+    krb5_keytab keytab = nullptr;
+    krb5_principal defcache_princ = nullptr;
+    String fmtError(krb5_error_code code) const;
+};
+}
+
+
+String KerberosInit::fmtError(krb5_error_code code) const
+{
+    const char *msg;
+    msg = krb5_get_error_message(k5.ctx, code);
+    String fmt_error = fmt::format(" ({}, {})", code, msg);
+    krb5_free_error_message(k5.ctx, msg);
+    return fmt_error;
+}
+
+void KerberosInit::init(const String & keytab_file, const String & principal, const String & cache_name)
+{
+    auto * log = &Poco::Logger::get("KerberosInit");
+    LOG_TRACE(log,"Trying to authenticate with Kerberos v5");
+
+    krb5_error_code ret;
+
+    const char *deftype = nullptr;
+
+    if (!std::filesystem::exists(keytab_file))
+        throw Exception(ErrorCodes::KERBEROS_ERROR, "Keytab file does not exist");
+
+    ret = krb5_init_context(&k5.ctx);
+    if (ret)
+        throw Exception(ErrorCodes::KERBEROS_ERROR, "Error while initializing Kerberos 5 library ({})", ret);
+
+    if (!cache_name.empty())
+    {
+        ret = krb5_cc_resolve(k5.ctx, cache_name.c_str(), &k5.out_cc);
+        if (ret)
+            throw Exception(ErrorCodes::KERBEROS_ERROR, "Error in resolving cache: {}", fmtError(ret));
+        LOG_TRACE(log,"Resolved cache");
+    }
+    else
+    {
+        // Resolve the default cache and get its type and default principal (if it is initialized).
+        ret = krb5_cc_default(k5.ctx, &defcache);
+        if (ret)
+            throw Exception(ErrorCodes::KERBEROS_ERROR, "Error while getting default cache: {}", fmtError(ret));
+        LOG_TRACE(log,"Resolved default cache");
+        deftype = krb5_cc_get_type(k5.ctx, defcache);
+        if (krb5_cc_get_principal(k5.ctx, defcache, &defcache_princ) != 0)
+            defcache_princ = nullptr;
+    }
+
+    // Use the specified principal name.
+    ret = krb5_parse_name_flags(k5.ctx, principal.c_str(), 0, &k5.me);
+    if (ret)
+        throw Exception(ErrorCodes::KERBEROS_ERROR, "Error when parsing principal name ({}): {}", principal, fmtError(ret));
+
+    // Cache related commands
+    if (k5.out_cc == nullptr && krb5_cc_support_switch(k5.ctx, deftype))
+    {
+        // Use an existing cache for the client principal if we can.
+        ret = krb5_cc_cache_match(k5.ctx, k5.me, &k5.out_cc);
+        if (ret && ret != KRB5_CC_NOTFOUND)
+            throw Exception(ErrorCodes::KERBEROS_ERROR, "Error while searching for cache for ({}): {}", principal, fmtError(ret));
+        if (0 == ret)
+        {
+            LOG_TRACE(log,"Using default cache: {}", krb5_cc_get_name(k5.ctx, k5.out_cc));
+            k5.switch_to_cache = 1;
+        }
+        else if (defcache_princ != nullptr)
+        {
+            // Create a new cache to avoid overwriting the initialized default cache.
+            ret = krb5_cc_new_unique(k5.ctx, deftype, nullptr, &k5.out_cc);
+            if (ret)
+                throw Exception(ErrorCodes::KERBEROS_ERROR, "Error while generating new cache: {}", fmtError(ret));
+            LOG_TRACE(log,"Using default cache: {}", krb5_cc_get_name(k5.ctx, k5.out_cc));
+            k5.switch_to_cache = 1;
+        }
+    }
+
+    // Use the default cache if we haven't picked one yet.
+    if (k5.out_cc == nullptr)
+    {
+        k5.out_cc = defcache;
+        defcache = nullptr;
+        LOG_TRACE(log,"Using default cache: {}", krb5_cc_get_name(k5.ctx, k5.out_cc));
+    }
+
+    ret = krb5_unparse_name(k5.ctx, k5.me, &k5.name);
+    if (ret)
+        throw Exception(ErrorCodes::KERBEROS_ERROR, "Error when unparsing name: {}", fmtError(ret));
+    LOG_TRACE(log,"Using principal: {}", k5.name);
+
+    // Allocate a new initial credential options structure.
+    ret = krb5_get_init_creds_opt_alloc(k5.ctx, &options);
+    if (ret)
+        throw Exception(ErrorCodes::KERBEROS_ERROR, "Error in options allocation: {}", fmtError(ret));
+
+    // Resolve keytab
+    ret = krb5_kt_resolve(k5.ctx, keytab_file.c_str(), &keytab);
+    if (ret)
+        throw Exception(ErrorCodes::KERBEROS_ERROR, "Error in resolving keytab ({}): {}", keytab_file, fmtError(ret));
+    LOG_TRACE(log,"Using keytab: {}", keytab_file);
+
+    // Set an output credential cache in initial credential options.
+    ret = krb5_get_init_creds_opt_set_out_ccache(k5.ctx, options, k5.out_cc);
+    if (ret)
+        throw Exception(ErrorCodes::KERBEROS_ERROR, "Error in setting output credential cache: {}", fmtError(ret));
+
+    // Action: init or renew
+    LOG_TRACE(log,"Trying to renew credentials");
+    memset(&my_creds, 0, sizeof(my_creds));
+    // Get renewed credential from KDC using an existing credential from output cache.
+    ret = krb5_get_renewed_creds(k5.ctx, &my_creds, k5.me, k5.out_cc, nullptr);
+    if (ret)
+    {
+        LOG_TRACE(log,"Renew failed {}", fmtError(ret));
+        LOG_TRACE(log,"Trying to get initial credentials");
+        // Request KDC for an initial credentials using keytab.
+        ret = krb5_get_init_creds_keytab(k5.ctx, &my_creds, k5.me, keytab, 0, nullptr, options);
+        if (ret)
+            throw Exception(ErrorCodes::KERBEROS_ERROR, "Error in getting initial credentials: {}", fmtError(ret));
+        else
+            LOG_TRACE(log,"Got initial credentials");
+    }
+    else
+    {
+        LOG_TRACE(log,"Successful renewal");
+        // Initialize a credential cache. Destroy any existing contents of cache and initialize it for the default principal.
+        ret = krb5_cc_initialize(k5.ctx, k5.out_cc, k5.me);
+        if (ret)
+            throw Exception(ErrorCodes::KERBEROS_ERROR, "Error when initializing cache: {}", fmtError(ret));
+        LOG_TRACE(log,"Initialized cache");
+        // Store credentials in a credential cache.
+        ret = krb5_cc_store_cred(k5.ctx, k5.out_cc, &my_creds);
+        if (ret)
+            LOG_TRACE(log,"Error while storing credentials");
+        LOG_TRACE(log,"Stored credentials");
+    }
+
+    if (k5.switch_to_cache)
+    {
+        // Make a credential cache the primary cache for its collection.
+        ret = krb5_cc_switch(k5.ctx, k5.out_cc);
+        if (ret)
+            throw Exception(ErrorCodes::KERBEROS_ERROR, "Error while switching to new cache: {}", fmtError(ret));
+    }
+
+    LOG_TRACE(log,"Authenticated to Kerberos v5");
+}
+
+KerberosInit::~KerberosInit()
+{
+    if (k5.ctx)
+    {
+        if (defcache)
+            krb5_cc_close(k5.ctx, defcache);
+        krb5_free_principal(k5.ctx, defcache_princ);
+
+        if (options)
+            krb5_get_init_creds_opt_free(k5.ctx, options);
+        if (my_creds.client == k5.me)
+            my_creds.client = nullptr;
+        krb5_free_cred_contents(k5.ctx, &my_creds);
+        if (keytab)
+            krb5_kt_close(k5.ctx, keytab);
+
+        krb5_free_unparsed_name(k5.ctx, k5.name);
+        krb5_free_principal(k5.ctx, k5.me);
+        if (k5.out_cc != nullptr)
+            krb5_cc_close(k5.ctx, k5.out_cc);
+        krb5_free_context(k5.ctx);
+    }
+}
+
+void kerberosInit(const String & keytab_file, const String & principal, const String & cache_name)
+{
+    // Using mutex to prevent cache file corruptions
+    static std::mutex kinit_mtx;
+    std::lock_guard lck(kinit_mtx);
+    KerberosInit k_init;
+    k_init.init(keytab_file, principal, cache_name);
+}
+#endif // USE_KRB5

--- a/src/Access/KerberosInit.h
+++ b/src/Access/KerberosInit.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016-2023 ClickHouse, Inc.
+ * Copyright 2023 Bytedance Ltd. and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <Common/config.h>
+#include <common/types.h>
+
+#if USE_KRB5
+
+void kerberosInit(const String & keytab_file, const String & principal, const String & cache_name = "");
+
+#endif // USE_KRB5

--- a/src/Access/examples/CMakeLists.txt
+++ b/src/Access/examples/CMakeLists.txt
@@ -1,0 +1,4 @@
+if (USE_KRB5)
+    add_executable (kerberos_init Kerberos_init.cpp)
+    target_link_libraries (kerberos_init PRIVATE dbms ${KRB5_LIBRARY} ${hdfs3})
+endif()

--- a/src/Access/examples/Kerberos_init.cpp
+++ b/src/Access/examples/Kerberos_init.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016-2023 ClickHouse, Inc.
+ * Copyright 2023 Bytedance Ltd. and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <Poco/ConsoleChannel.h>
+#include <Poco/Logger.h>
+#include <Poco/AutoPtr.h>
+#include <Common/Exception.h>
+#include <Access/KerberosInit.h>
+
+/** The example demonstrates using of kerberosInit function to obtain and cache Kerberos ticket-granting ticket.
+  * The first argument specifies keytab file. The second argument specifies principal name.
+  * The third argument is optional. It specifies credentials cache location.
+  * After successful run of kerberos_init it is useful to call klist command to list cached Kerberos tickets.
+  * It is also useful to run kdestroy to destroy Kerberos tickets if needed.
+  */
+
+using namespace DB;
+
+int main(int argc, char ** argv)
+{
+    std::cout << "Kerberos Init" << "\n";
+
+    if (argc < 3)
+    {
+        std::cout << "kerberos_init obtains and caches an initial ticket-granting ticket for principal." << "\n\n";
+        std::cout << "Usage:" << "\n" << "    kerberos_init keytab principal [cache]" << "\n";
+        return 0;
+    }
+
+    const char * cache_name = "";
+    if (argc == 4)
+        cache_name = argv[3];
+
+    Poco::AutoPtr<Poco::ConsoleChannel> app_channel(new Poco::ConsoleChannel(std::cerr));
+    Poco::Logger::root().setChannel(app_channel);
+    Poco::Logger::root().setLevel("trace");
+
+    try
+    {
+        kerberosInit(argv[1], argv[2], cache_name);
+    }
+    catch (const Exception & e)
+    {
+        std::cout << "KerberosInit failure: " << getExceptionMessage(e, false) << "\n";
+        return -1;
+    }
+    std::cout << "Done" << "\n";
+    return 0;
+}

--- a/src/Common/config.h.in
+++ b/src/Common/config.h.in
@@ -20,3 +20,4 @@
 #cmakedefine01 USE_RDKAFKA
 #cmakedefine01 USE_BREAKPAD
 #cmakedefine01 BYTEJOURNAL_AVAILABLE
+#cmakedefine01 USE_KRB5

--- a/src/Storages/CMakeLists.txt
+++ b/src/Storages/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(System)
 
 if(ENABLE_EXAMPLES)
     add_subdirectory(examples)
+    add_subdirectory(HDFS/examples)
 endif()
 
 # tools for verifying hdfs.

--- a/src/Storages/HDFS/HDFSAuth.cpp
+++ b/src/Storages/HDFS/HDFSAuth.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 Bytedance Ltd. and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <Common/config.h>
+
+#if USE_KRB5
+
+#include <Storages/HDFS/HDFSAuth.h>
+#include <string>
+#include <Access/KerberosInit.h>
+#include <Storages/HDFS/HDFSCommon.h>
+#include <hdfs/hdfs.h>
+#include <Poco/Util/AbstractConfiguration.h>
+#include <common/logger_useful.h>
+#include <common/types.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int EXCESSIVE_ELEMENT_IN_CONFIG;
+}
+
+HDFSKrb5Params
+HDFSKrb5Params::parseKrb5FromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_prefix, bool isUser)
+{
+    auto config_key = [&config_prefix](const String & key) { return config_prefix.empty() ? key : config_prefix + "." + key; };
+
+    const String kerberos_keytab = config_key("hadoop_kerberos_keytab");
+    const String kerberos_principal = config_key("hadoop_kerberos_principal");
+    const String kerberos_ticket_cache_path = config_key("hadoop_security_kerberos_ticket_cache_path");
+
+    HDFSKrb5Params krb5_params;
+
+    if (config.has(kerberos_keytab))
+    {
+        krb5_params.need_kinit = true;
+        krb5_params.hadoop_kerberos_keytab = config.getString(kerberos_keytab);
+    }
+
+    if (config.has(kerberos_principal))
+    {
+        krb5_params.need_kinit = true;
+        krb5_params.hadoop_kerberos_principal = config.getString(kerberos_principal);
+    }
+
+    if (config.has(kerberos_ticket_cache_path))
+    {
+        if (isUser)
+        {
+            throw Exception("hadoop.security.kerberos.ticket.cache.path cannot be set per user", ErrorCodes::EXCESSIVE_ELEMENT_IN_CONFIG);
+        }
+        krb5_params.hadoop_security_kerberos_ticket_cache_path = config.getString(kerberos_ticket_cache_path);
+    }
+
+    return krb5_params;
+}
+
+void HDFSKrb5Params::setHDFSKrb5Config(hdfsBuilder * builder) const
+{
+    hdfsBuilderSetPrincipal(builder, hadoop_kerberos_principal.c_str());
+    if (!hadoop_security_kerberos_ticket_cache_path.empty())
+    {
+        hdfsBuilderSetKerbTicketCachePath(builder, hadoop_security_kerberos_ticket_cache_path.c_str());
+    }
+}
+
+void HDFSKrb5Params::runKinit() const
+{
+    if (need_kinit)
+    {
+        LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "Running KerberosInit");
+        kerberosInit(hadoop_kerberos_keytab, hadoop_kerberos_principal, hadoop_security_kerberos_ticket_cache_path);
+        LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "Finished KerberosInit");
+    }
+}
+
+}
+#endif // USE_KRB5

--- a/src/Storages/HDFS/HDFSAuth.h
+++ b/src/Storages/HDFS/HDFSAuth.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Bytedance Ltd. and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <Common/config.h>
+
+#if USE_KRB5
+#include <string>
+#include <hdfs/hdfs.h>
+#include <Poco/Util/AbstractConfiguration.h>
+#include <common/types.h>
+
+class HDFSBuilderPtr;
+
+namespace DB
+{
+
+class HDFSKrb5Params
+{
+public:
+    String hadoop_kerberos_keytab;
+    String hadoop_kerberos_principal;
+    String hadoop_security_kerberos_ticket_cache_path;
+
+    bool need_kinit{false};
+
+    static HDFSKrb5Params
+    parseKrb5FromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_prefix = "", bool isUser = false);
+
+    void setHDFSKrb5Config(hdfsBuilder * builder) const;
+    void runKinit() const;
+};
+
+}
+#endif //USE_KRB5

--- a/src/Storages/HDFS/HDFSCommon.h
+++ b/src/Storages/HDFS/HDFSCommon.h
@@ -40,6 +40,7 @@
 #include <Poco/URI.h>
 #include <random>
 #include <Common/HostWithPorts.h>
+#include <Storages/HDFS/HDFSAuth.h>
 namespace DB
 {
 inline bool isHdfsScheme(const std::string & scheme)
@@ -120,7 +121,6 @@ struct HDFSFileInfo
 using HDFSBuilderPtr = std::unique_ptr<hdfsBuilder, detail::HDFSBuilderDeleter>;
 using HDFSFSPtr = std::shared_ptr<std::remove_pointer_t<hdfsFS>>;
 
-
 class HDFSConnectionParams
 {
 public:
@@ -142,6 +142,7 @@ public:
     String hdfs_user;
     String hdfs_service;
     std::vector<IpWithPort> addrs;
+    HDFSKrb5Params krb5_params;
 
     bool use_nnproxy_ha = false; // for whether to use ha config for nnproxies.
     bool inited = false;

--- a/src/Storages/HDFS/examples/CMakeLists.txt
+++ b/src/Storages/HDFS/examples/CMakeLists.txt
@@ -1,0 +1,4 @@
+if (USE_KRB5)
+    add_executable (hdfs_krb5 Hdfs_krb5.cpp)
+    target_link_libraries (hdfs_krb5 PRIVATE dbms ${KRB5_LIBRARY} ${HDFS3_LIBRARY})
+endif()

--- a/src/Storages/HDFS/examples/Hdfs_krb5.cpp
+++ b/src/Storages/HDFS/examples/Hdfs_krb5.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 Bytedance Ltd. and/or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <string>
+#include <hdfs/hdfs.h>
+#include <Access/KerberosInit.h>
+#include <Poco/ConsoleChannel.h>
+#include <Poco/Logger.h>
+#include <Poco/AutoPtr.h>
+#include <Poco/URI.h>
+#include <Common/Exception.h>
+#include <Access/KerberosInit.h>
+
+
+/**
+ * The example is used to check krb5 keytab and principal
+ * can access the hdfs with krb5 for listing hdfs path
+ * hdfs://user @ host : port/ path /
+*/
+using namespace DB;
+
+int main(int argc, char ** argv)
+{
+    std::cout << "Kerberos Init" << "\n";
+
+    if (argc != 5)
+    {
+        std::cout << "kerberos_init obtains and caches an initial ticket-granting ticket for principal." << "\n\n";
+        std::cout << "Usage:" << "\n" << "hdfs_krb5 keytab principal cache_path hdfs_path" << "\n";
+        std::cout << "hdfs_path : hdfs://host:port/path/" << "\n";
+        return 0;
+    }
+
+    Poco::AutoPtr<Poco::ConsoleChannel> app_channel(new Poco::ConsoleChannel(std::cerr));
+    Poco::Logger::root().setChannel(app_channel);
+    Poco::Logger::root().setLevel("trace");
+
+    try
+    {
+        kerberosInit(argv[1], argv[2], argv[3]);
+    }
+    catch (const Exception & e)
+    {
+        std::cout << "KerberosInit failure: " << getExceptionMessage(e, false) << "\n";
+        return -1;
+    }
+
+
+    std::cout << "KerberosInit success" << "\n";
+
+    const Poco::URI hdfs_uri(argv[4]);
+
+
+    std::cout << "Try List HDFS Path" << "\n";
+
+    auto builder = hdfsNewBuilder() ;
+
+    hdfsBuilderSetNameNode(builder, hdfs_uri.getHost().c_str());
+    std::cout << "NameNode: " << hdfs_uri.getHost()<< "\n";
+
+    hdfsBuilderSetNameNodePort(builder, hdfs_uri.getPort());
+    std::cout << "Port: " << hdfs_uri.getPort() << "\n";
+
+    hdfsBuilderSetPrincipal(builder, argv[2]);
+    std::cout << "Principal: " << argv[2] << "\n";
+
+    std::string auth_method_key = "hadoop.security.authentication" ;
+    std::string auth_method = "KERBEROS";
+    hdfsBuilderConfSetStr(builder, auth_method_key.c_str(), auth_method.c_str());
+
+    hdfsBuilderSetKerbTicketCachePath(builder, argv[3]);
+
+    auto fs = hdfsBuilderConnect(builder);
+    int file_num = 0 ;
+
+    auto file_info = hdfsListDirectory(fs, hdfs_uri.getPath().c_str(), &file_num);
+
+    for (int i = 0 ; i < file_num ; i++)
+    {
+        std::cout << i << ": "<<file_info[i].mName << "\n";
+    }
+
+    std::cout<< "error:" << std::string(hdfsGetLastError()) <<std::endl;
+
+    return 0 ;
+}


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->

<!-- If you are doing this for the first time, it's recommended to read the lightweight Contributing to ByConity Documentation https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md guide first. -->

### Changelog category <!-- please remove the below items and leave one that you choose -->:
- New Feature



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

add krb5 support for hdfs

### Documentation entry for user-facing changes

     add conf in server.xml in <yandex></yandex>

    <hadoop_kerberos_keytab>/path/to/keytab</hadoop_kerberos_keytab>
    <hadoop_kerberos_principal>kerberos_principal</hadoop_kerberos_principal>
    <hadoop_security_kerberos_ticket_cache_path>/ticket/cache/path</hadoop_security_kerberos_ticket_cache_path>

    add conf in hdfs3.xml like 
    <property>
        <name>hadoop.security.authentication</name>
        <value>KERBEROS</value>
    </property>
    <property>
        <name>dfs.use.internal.credential.format</name>
        <value>false</value>
    </property>
    <property>
        <name>dfs.data.transfer.protection</name>
        <value>authentication</value>
    </property>
    <property>
        <name>dfs.block.access.token.enable</name>
        <value>true</value>
    </property>
<!---

Add a user-readable short description of the changes that should be added to https://github.com/ByConity/byconity.github.io below.

At a minimum, the following information should be added (but add more as needed).

- Motivation: Why is this function, table engine, etc. useful to ByConity users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
