### PR TITLE
fix fmt cannot write to file

### DIFF
--- a/src/Disks/DiskHelpers.cpp
+++ b/src/Disks/DiskHelpers.cpp
@@ -45,7 +45,6 @@ DiskPtr getDiskForPathId(const StoragePolicyPtr& storage_policy, UInt32 path_id)
     VolumePtr remote_volume = storage_policy->getVolume(0);
     String disk_name = getDiskNameForPathId(remote_volume, path_id);
     DiskPtr disk = storage_policy->getDiskByName(disk_name);
-    fmt::print(stderr, "Getting disk {}:{} from volumn {} with storage policy {}\n", disk_name, disk->getPath(), remote_volume->getName(), storage_policy->getName());
     if (disk == nullptr)
         throw Exception("Disk " + disk_name + " not found in " + storage_policy->getName(),
             ErrorCodes::INVALID_CONFIG_PARAMETER);


### PR DESCRIPTION
### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Bug Fix

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes https://github.com/ByConity/ByConity/issues/154. When the process go into background the `stderr` is closed. Hence the fmt can't write to this stderr. It throw exception
```
2023.03.31 11:40:11.517116 [ 2444357 ] {9dbe212d-5708-4884-aa68-7c716f30b340} <Error> TCPHandler: Code: 1001, e.displayText() = DB::Exception: fmt::v7::system_error: cannot write to file: Input/output error SQLSTATE: HY000, Stack trace:

0. /data01/minh.dao/git/cnch-ce-merge/ClickHouse/contrib/libcxx/include/exception:133: std::runtime_error::runtime_error(char const*) @ 0x19301170 in /data01/minh.dao/git/cnch-ce-merge/ClickHouse/build/programs/clickhouse
1. /data01/minh.dao/git/cnch-ce-merge/ClickHouse/contrib/fmtlib-cmake/../fmtlib/include/fmt/format.h:3000: fmt::v7::system_error::system_error<>(int, fmt::v7::basic_string_view<char>) @ 0x190fa925 in /data01/minh.dao/git/cnch-ce-merge/ClickHouse/build/programs/clickhouse
2. /data01/minh.dao/git/cnch-ce-merge/ClickHouse/contrib/fmtlib-cmake/../fmtlib/include/fmt/format-inl.h:179: fmt::v7::vprint(_IO_FILE*, fmt::v7::basic_string_view<char>, fmt::v7::format_args) @ 0x190fa843 in /data01/minh.dao/git/cnch-ce-merge/ClickHouse/build/programs/clickhouse
3. /data01/minh.dao/git/cnch-ce-merge/ClickHouse/contrib/libcxx/include/memory:2851: DB::getDiskForPathId(std::__1::shared_ptr<DB::IStoragePolicy const> const&, unsigned int) @ 0x13c7082a in /data01/minh.dao/git/cnch-ce-merge/ClickHouse/build/programs/clickhouse
4. /data01/minh.dao/git/cnch-ce-merge/ClickHouse/src/Protos/DataModelHelpers.cpp:82:
```
