### PR TITLE
In-memory cache for primary key index

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1067,6 +1067,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
             formatReadableSizeWithBinarySuffix(mark_cache_size));
     }
     global_context->setMarkCache(mark_cache_size);
+    global_context->setPrimaryIndexCache(mark_cache_size);
     global_context->setChecksumsCache(config().getUInt64("checksum_cache_size", 10737418240)); // 10GB
 
     /// Size of cache for query. It is not necessary.

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -65,6 +65,8 @@
     M(TableFunctionExecute, "") \
     M(MarkCacheHits, "") \
     M(MarkCacheMisses, "") \
+    M(PrimaryIndexCacheHits, "") \
+    M(PrimaryIndexCacheMisses, "") \
     M(QueryCacheHits, "") \
     M(QueryCacheMisses, "") \
     M(ChecksumsCacheHits, "") \

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -103,6 +103,7 @@ class Compiler;
 class MarkCache;
 class MMappedFileCache;
 class UncompressedCache;
+class PrimaryIndexCache;
 class ProcessList;
 class ProcessListEntry;
 class PlanSegment;
@@ -937,6 +938,10 @@ public:
     void setMarkCache(size_t cache_size_in_bytes);
     std::shared_ptr<MarkCache> getMarkCache() const;
     void dropMarkCache() const;
+
+    void setPrimaryIndexCache(size_t cache_size_in_bytes);
+    std::shared_ptr<PrimaryIndexCache> getPrimaryIndexCache() const;
+    void dropPrimaryIndexCache() const;
 
     /// Create a cache of queries of specified size. This can be done only once.
     void setQueryCache(size_t cache_size_in_bytes);

--- a/src/MergeTreeCommon/MergeTreeMetaBase.cpp
+++ b/src/MergeTreeCommon/MergeTreeMetaBase.cpp
@@ -101,9 +101,8 @@ MergeTreeMetaBase::MergeTreeMetaBase(
     , pinned_part_uuids(std::make_shared<PinnedPartUUIDs>())
     , data_parts_by_info(data_parts_indexes.get<TagByInfo>())
     , data_parts_by_state_and_info(data_parts_indexes.get<TagByStateAndInfo>())
+    , primary_index_cache(context_->getPrimaryIndexCache())
     , relative_data_path(relative_data_path_)
-    /// FIXME: add after supporting primary key index cache
-    // , primary_index_cache(context_->getDiskPrimaryKeyIndexCache())
 {
     const auto & settings = getSettings();
     allow_nullable_key = attach_ || settings->allow_nullable_key || settings->enable_nullable_sorting_key;

--- a/src/MergeTreeCommon/MergeTreeMetaBase.h
+++ b/src/MergeTreeCommon/MergeTreeMetaBase.h
@@ -21,11 +21,11 @@
 #include <Storages/extractKeyExpressionList.h>
 #include <Storages/MergeTree/PinnedPartUUIDs.h>
 #include <Storages/MergeTree/MergeTreeMeta.h>
+#include <Storages/PrimaryIndexCache.h>
 #include <MergeTreeCommon/IMergeTreePartMeta.h>
 #include <Processors/Merges/Algorithms/Graphite.h>
 #include <Common/SimpleIncrement.h>
 #include <Disks/StoragePolicy.h>
-
 
 namespace DB
 {
@@ -489,8 +489,7 @@ protected:
             throw Exception("Can't modify " + (*it)->getNameWithState(), ErrorCodes::LOGICAL_ERROR);
     }
 
-    /// FIXME: add after supporting primary index cache
-    // PrimaryIndexCachePtr primary_index_cache;
+    PrimaryIndexCachePtr primary_index_cache;
 
     void checkProperties(const StorageInMemoryMetadata & new_metadata, const StorageInMemoryMetadata & old_metadata, bool attach = false) const;
 

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -620,8 +620,11 @@ private:
     /// Loads marks index granularity into memory
     virtual void loadIndexGranularity();
 
+    /// Loads index from cache
+    void loadIndexFromCache();
+
     /// Loads index file.
-    virtual void loadIndex();
+    virtual IndexPtr loadIndex();
 
     /// Load rows count for this part from disk (for the newer storage format version).
     /// For the older format version calculates rows count from the size of a column with a fixed size.

--- a/src/Storages/MergeTree/MergeTreeDataPartCNCH.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartCNCH.h
@@ -96,7 +96,7 @@ private:
 
     void checkConsistency(bool require_part_metadata) const override;
 
-    void loadIndex() override;
+    IndexPtr loadIndex() override;
 
     MergeTreeDataPartChecksums::FileChecksums loadPartDataFooter() const;
 

--- a/src/Storages/PrimaryIndex.h
+++ b/src/Storages/PrimaryIndex.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (2022) Bytedance Ltd. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#pragma once
+
+#include <memory>
+#include <Columns/IColumn.h>
+
+namespace DB
+{
+using PrimaryIndex = Columns;
+using PrimaryIndexPtr = std::shared_ptr<Columns>;
+
+}

--- a/src/Storages/PrimaryIndexCache.h
+++ b/src/Storages/PrimaryIndexCache.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (2022) Bytedance Ltd. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#pragma once
+
+#include <Storages/PrimaryIndex.h>
+#include <Storages/UUIDAndPartName.h>
+#include <Common/LRUCache.h>
+#include <Common/ProfileEvents.h>
+
+namespace ProfileEvents
+{
+extern const Event PrimaryIndexCacheHits;
+extern const Event PrimaryIndexCacheMisses;
+}
+
+namespace DB
+{
+struct PrimaryIndexWeightFunction
+{
+    size_t operator()(const PrimaryIndex & index) const
+    {
+        size_t sum_bytes = 0;
+        for (auto & column : index)
+            sum_bytes += column->allocatedBytes();
+        return sum_bytes;
+    }
+};
+
+
+class PrimaryIndexCache
+    : public LRUCache<UUIDAndPartName, PrimaryIndex, UUIDAndPartNameHash, PrimaryIndexWeightFunction>
+{
+    using Base = LRUCache<UUIDAndPartName, PrimaryIndex, UUIDAndPartNameHash, PrimaryIndexWeightFunction>;
+
+public:
+    using Base::Base;
+
+    template <typename LoadFunc>
+    std::pair<MappedPtr, bool> getOrSet(const Key & key, LoadFunc && load)
+    {
+        auto result = Base::getOrSet(key, load);
+        if (result.second)
+            ProfileEvents::increment(ProfileEvents::PrimaryIndexCacheMisses);
+        else
+            ProfileEvents::increment(ProfileEvents::PrimaryIndexCacheHits);
+        return result;
+    }
+};
+
+using PrimaryIndexCachePtr = std::shared_ptr<PrimaryIndexCache>;
+
+} /// EOF


### PR DESCRIPTION
### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

-  Cache hot primary key index in memory.

Trying to solve https://github.com/ByConity/ByConity/issues/205

