### PR TITLE
old kernel hdfs support

### DIFF
--- a/contrib/libhdfs3-open-cmake/CMakeLists.txt
+++ b/contrib/libhdfs3-open-cmake/CMakeLists.txt
@@ -57,6 +57,10 @@ file(GLOB_RECURSE SRCS
         "${HDFS3_SOURCE_DIR}/*.h"
         "${HDFS3_SOURCE_DIR}/*.cpp"
         )
+
+# old kernels (< 3.17) doesn't have SYS_getrandom. Always use POSIX implementation to have better compatibility
+set_source_files_properties("${HDFS3_SOURCE_DIR}/rpc/RpcClient.cpp" PROPERTIES COMPILE_FLAGS "-DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX=1")
+
 # target
 add_library(hdfs3 STATIC ${SRCS} ${PROTO_SOURCES} ${PROTO_HEADERS})
 


### PR DESCRIPTION
### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
old kernels (< 3.17) don't have SYS_getrandom. Always use POSIX implementation to have better compatibility

fix: #210 