### PR TITLE
fix: add calculate column sizes

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataPartCNCH.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartCNCH.cpp
@@ -247,6 +247,7 @@ void MergeTreeDataPartCNCH::loadColumnsChecksumsIndexes([[maybe_unused]] bool re
     MemoryTracker::BlockerInThread temporarily_disable_memory_tracker(VariableContext::Global);
     getChecksums();
     loadIndexGranularity();
+    calculateEachColumnSizes(columns_sizes, total_columns_size);
 
     /// FIXME:
     default_codec = CompressionCodecFactory::instance().getDefaultCodec();
@@ -693,6 +694,62 @@ void MergeTreeDataPartCNCH::loadMetaInfoFromBuffer(ReadBuffer & buf, bool load_h
 void MergeTreeDataPartCNCH::calculateEachColumnSizes(
     [[maybe_unused]] ColumnSizeByName & each_columns_size, [[maybe_unused]] ColumnSize & total_size) const
 {
+    std::unordered_set<String> processed_substreams;
+    for (const NameAndTypePair & column : *columns_ptr)
+    {
+        ColumnSize size = getColumnSizeImpl(column, &processed_substreams);
+        each_columns_size[column.name] = size;
+        total_size.add(size);
+
+#ifndef NDEBUG
+        /// Most trivial types
+        if (rows_count != 0 && column.type->isValueRepresentedByNumber() && !column.type->haveSubtypes())
+        {
+            size_t rows_in_column = size.data_uncompressed / column.type->getSizeOfValueInMemory();
+            if (rows_in_column != rows_count)
+            {
+                throw Exception(
+                    ErrorCodes::LOGICAL_ERROR,
+                    "Column {} has rows count {} according to size in memory "
+                    "and size of single value, but data part {} has {} rows", backQuote(column.name), rows_in_column, name, rows_count);
+            }
+        }
+#endif
+    }
+}
+
+ColumnSize MergeTreeDataPartCNCH::getColumnSizeImpl(const NameAndTypePair & column, std::unordered_set<String> * processed_substreams) const
+{
+    ColumnSize size;
+    auto checksums = getChecksums();
+    if (checksums->empty())
+        return size;
+
+    // Special handling flattened map type
+    if (column.type->isMap() && !column.type->isMapKVStore())
+        return getMapColumnSizeNotKV(checksums, column);
+
+    auto serialization = getSerializationForColumn(column);
+    serialization->enumerateStreams([&](const ISerialization::SubstreamPath & substream_path)
+    {
+        String file_name = ISerialization::getFileNameForStream(column, substream_path);
+
+        if (processed_substreams && !processed_substreams->insert(file_name).second)
+            return;
+
+        auto bin_checksum = checksums->files.find(file_name + DATA_FILE_EXTENSION);
+        if (bin_checksum != checksums->files.end())
+        {
+            size.data_compressed += bin_checksum->second.file_size;
+            size.data_uncompressed += bin_checksum->second.uncompressed_size;
+        }
+
+        auto mrk_checksum = checksums->files.find(file_name + index_granularity_info.marks_file_extension);
+        if (mrk_checksum != checksums->files.end())
+            size.marks += mrk_checksum->second.file_size;
+    }, {});
+
+    return size;
 }
 
 void MergeTreeDataPartCNCH::removeImpl(bool keep_shared_data) const

--- a/src/Storages/MergeTree/MergeTreeDataPartCNCH.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartCNCH.h
@@ -112,6 +112,7 @@ private:
     void loadMetaInfoFromBuffer(ReadBuffer & buffer, bool load_hint_mutation);
 
     void calculateEachColumnSizes(ColumnSizeByName & each_columns_size, ColumnSize & total_size) const override;
+    ColumnSize getColumnSizeImpl(const NameAndTypePair & column, std::unordered_set<String> * processed_substreams) const;
 
     void removeImpl(bool keep_shared_data) const override;
 };


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->

<!-- If you are doing this for the first time, it's recommended to read the lightweight Contributing to ByConity Documentation https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md guide first. -->

### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Bug Fix


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
implement calculate column size for MergeTreeDataPartCNCH
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---

Add a user-readable short description of the changes that should be added to https://github.com/ByConity/byconity.github.io below.

At a minimum, the following information should be added (but add more as needed).

- Motivation: Why is this function, table engine, etc. useful to ByConity users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
