### PR TITLE
fix: dns service discovery mode not work in k8s

### DIFF
--- a/contrib/udns-cmake/CMakeLists.txt
+++ b/contrib/udns-cmake/CMakeLists.txt
@@ -1,16 +1,8 @@
 set(LIBRARY_DIR ${ClickHouse_SOURCE_DIR}/contrib/udns)
 set(UDNS_INCLUDE_DIR ${LIBRARY_DIR})
-add_definitions(-DHAVE_CONFIG_H)
-
-add_custom_target(
-    udns_config
-    COMMAND ${LIBRARY_DIR}/configure
-    WORKING_DIRECTORY ${LIBRARY_DIR})
 
 file(GLOB UDNS_DIR_SRC "${LIBRARY_DIR}/*.c")
 
 add_library(udns STATIC ${UDNS_DIR_SRC})
-
-add_dependencies(udns udns_config)
 
 target_include_directories(udns PRIVATE ${LIBRARY_DIR})

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -606,12 +606,6 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
     Catalog::CatalogConfig catalog_conf(global_context->getCnchConfigRef());
 
-    std::string current_raw_sd_config;
-    if (config().has("service_discovery")) // only important for local mode (for observing if the sd section is changed)
-    {
-        current_raw_sd_config = config().getRawString("service_discovery");
-    }
-
     /// Initialize components in server or worker.
     if (global_context->getServerType() == ServerType::cnch_server || global_context->getServerType() == ServerType::cnch_worker)
     {


### PR DESCRIPTION
### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Bug Fix

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
When ByConity is deployed in k8s, the service discovery module will work in `dns` mode. It didn't use the DNS server address specify in `/etc/resolv.conf`. The reason because in udns library is build with `HAVE_CONFIG_H` flags disabled. So i fix the way the library is built by updating `CMakeLists.txt` file

I also removed some dead code
