### PR TITLE
auto forward query to host server when having multiple servers

### DIFF
--- a/src/CloudServices/CnchServerServiceImpl.cpp
+++ b/src/CloudServices/CnchServerServiceImpl.cpp
@@ -15,6 +15,7 @@
 
 #include <CloudServices/CnchServerServiceImpl.h>
 
+#include <Catalog/Catalog.h>
 #include <Protos/RPCHelpers.h>
 #include <MergeTreeCommon/MergeTreeMetaBase.h>
 #include <MergeTreeCommon/CnchTopologyMaster.h>
@@ -860,12 +861,65 @@ void CnchServerServiceImpl::getDeletingTablesInGlobalGC(
         tryLogCurrentException(log, __PRETTY_FUNCTION__);
     }
 }
+
+void CnchServerServiceImpl::handleRedirectCommitRequest(
+    [[maybe_unused]] google::protobuf::RpcController* controller,
+    [[maybe_unused]] const Protos::RedirectCommitPartsReq * request,
+    [[maybe_unused]] Protos::RedirectCommitPartsResp * response,
+    [[maybe_unused]] google::protobuf::Closure * done,
+    bool final_commit)
+{
+    RPCHelpers::serviceHandler(done, response, [request = request, response = response, done = done, final_commit=final_commit, &global_context = *getContext(), log = log] {
+        brpc::ClosureGuard done_guard(done);
+        try
+        {
+            String table_uuid = UUIDHelpers::UUIDToString(RPCHelpers::createUUID(request->uuid()));
+            StoragePtr storage = global_context.getCnchCatalog()->tryGetTableByUUID(
+                global_context, table_uuid, TxnTimestamp::maxTS());
+
+            if (!storage)
+                throw Exception("Table with uuid " + table_uuid + " not found.", ErrorCodes::UNKNOWN_TABLE);
+
+            auto * cnch = dynamic_cast<MergeTreeMetaBase *>(storage.get());
+            if (!cnch)
+                throw Exception("Table is not of MergeTree class", ErrorCodes::BAD_ARGUMENTS);
+
+            auto parts = createPartVectorFromModels<MergeTreeDataPartCNCHPtr>(*cnch, request->parts(), nullptr);
+            auto staged_parts = createPartVectorFromModels<MergeTreeDataPartCNCHPtr>(*cnch, request->staged_parts(), nullptr);
+            DeleteBitmapMetaPtrVector delete_bitmaps;
+            delete_bitmaps.reserve(request->delete_bitmaps_size());
+            for (auto & bitmap_model : request->delete_bitmaps())
+                delete_bitmaps.emplace_back(createFromModel(*cnch, bitmap_model));
+
+
+            if (!final_commit)
+            {
+                TxnTimestamp txnID{request->txn_id()};
+                global_context.getCnchCatalog()->writeParts(storage, txnID,
+                    Catalog::CommitItems{parts, delete_bitmaps, staged_parts}, request->from_merge_task(), request->preallocate_mode());
+            }
+            else
+            {
+                TxnTimestamp commitTs {request->commit_ts()};
+                global_context.getCnchCatalog()->setCommitTime(storage, Catalog::CommitItems{parts, delete_bitmaps, staged_parts},
+                    commitTs, request->txn_id());
+            }
+        }
+        catch (...)
+        {
+            tryLogCurrentException(log, __PRETTY_FUNCTION__);
+            RPCHelpers::handleException(response->mutable_exception());
+        }
+    });
+}
+
 void CnchServerServiceImpl::redirectCommitParts(
     google::protobuf::RpcController * controller,
     const Protos::RedirectCommitPartsReq * request,
     Protos::RedirectCommitPartsResp * response,
     google::protobuf::Closure * done)
 {
+    handleRedirectCommitRequest(controller, request, response, done, false);
 }
 void CnchServerServiceImpl::redirectSetCommitTime(
     google::protobuf::RpcController * controller,
@@ -873,6 +927,7 @@ void CnchServerServiceImpl::redirectSetCommitTime(
     Protos::RedirectCommitPartsResp * response,
     google::protobuf::Closure * done)
 {
+    handleRedirectCommitRequest(controller, request, response, done, true);
 }
 void CnchServerServiceImpl::removeMergeMutateTasksOnPartition(
     google::protobuf::RpcController * cntl,
@@ -881,6 +936,7 @@ void CnchServerServiceImpl::removeMergeMutateTasksOnPartition(
     google::protobuf::Closure * done)
 {
 }
+
 void CnchServerServiceImpl::submitQueryWorkerMetrics(
     google::protobuf::RpcController * /*cntl*/,
     const Protos::SubmitQueryWorkerMetricsReq * request,

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -850,6 +850,7 @@ class IColumn;
     M(UInt64, cnch_part_attach_max_threads, 16, "Max threads to use when attach parts", 0) \
     M(UInt64, attach_failure_injection_knob, 0, "Attach failure injection knob, for test only", 0) \
     M(Bool, async_post_commit, false, "Txn post commit asynchronously", 0) \
+    M(Bool, enable_auto_query_forwarding, false, "Auto forward query to target server when having multiple servers", 0) \
 
 
 // End of FORMAT_FACTORY_SETTINGS

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -582,7 +582,7 @@ class IColumn;
     M(Milliseconds, topology_lease_life_ms, 12000, "Expiration time of topology lease.", 0) \
     M(Milliseconds, topology_session_restart_check_ms, 120, "Check and try to restart leader election for server master", 0) \
     M(UInt64, catalog_max_commit_size, 2000, "Max record number to be committed in one batch.", 0) \
-    M(Bool, server_write_ha, true, "Whether to enable write on non-host server if host server is not available. Directly commit from non-host server.", 0) \
+    M(Bool, server_write_ha, false, "Whether to enable write on non-host server if host server is not available. Directly commit from non-host server.", 0) \
     M(Bool, enable_write_non_host_server, true, "Whether to eable write on non-host server. Will root write request to host server.", 0) \
     M(UInt64, cnch_clear_parts_timeout, 10, "Wait for actions to clear the parts in workers within the specified number of seconds. 0 - wait unlimited time.", 0) \
     M(Seconds, cnch_fetch_parts_timeout, 60, "The timeout for gettting parts from metastore. 0 - wait unlimited time.", 0) \

--- a/src/DataStreams/BlockIO.cpp
+++ b/src/DataStreams/BlockIO.cpp
@@ -89,6 +89,8 @@ BlockIO & BlockIO::operator= (BlockIO && rhs)
 
     null_format             = std::move(rhs.null_format);
 
+    remote_execution_conn = std::move(rhs.remote_execution_conn);
+
     return *this;
 }
 

--- a/src/DataStreams/BlockIO.h
+++ b/src/DataStreams/BlockIO.h
@@ -21,10 +21,9 @@
 
 #pragma once
 
+#include <Client/Connection.h>
 #include <DataStreams/IBlockStream_fwd.h>
-
 #include <functional>
-
 #include <Processors/QueryPipeline.h>
 
 
@@ -61,6 +60,8 @@ struct BlockIO
     bool null_format = false;
 
     Stopwatch watch;
+
+    ConnectionPtr remote_execution_conn;
 
     /// Call these functions if you want to log the request.
     void onFinish()

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1614,7 +1614,7 @@ void executeQueryByProxy(ContextMutablePtr context, const HostWithPorts & server
     auto settings = context->getSettingsRef();
     res.remote_execution_conn = std::make_shared<Connection>(
         server.getHost(), server.tcp_port, 
-        "", /*default_database_*/
+        context->getCurrentDatabase(), /*default_database_*/
         query_client_info.current_user, query_client_info.current_password, 
         "", /*cluster_*/
         "", /*cluster_secret*/

--- a/src/Interpreters/executeQuery.h
+++ b/src/Interpreters/executeQuery.h
@@ -77,4 +77,10 @@ BlockIO executeQuery(
     bool allow_processors /// If can use processors pipeline
 );
 
+/// Get target server for a query, can be localhost
+HostWithPorts getTargetServer(ContextPtr context, ASTPtr & ast);
+
+/// Execute the query on the target server.
+void executeQueryByProxy(ContextMutablePtr context, const HostWithPorts & server, const ASTPtr & ast, BlockIO & res);
+
 }

--- a/src/Transaction/TransactionCoordinatorRcCnch.cpp
+++ b/src/Transaction/TransactionCoordinatorRcCnch.cpp
@@ -27,6 +27,7 @@
 #include <Common/ProfileEvents.h>
 #include <Common/ThreadPool.h>
 #include <common/getFQDNOrHostName.h>
+#include "Transaction/TxnTimestamp.h"
 #include <Interpreters/Context.h>
 // #include <MergeTreeCommon/CnchWorkerClientPools.h>
 
@@ -119,9 +120,12 @@ ProxyTransactionPtr TransactionCoordinatorRcCnch::createProxyTransaction(
             if (!active_txn_list.emplace(txn_id, txn).second)
                 throw Exception("Transaction (txn_id: " + txn_id.toString() + ") has been created", ErrorCodes::LOGICAL_ERROR);
         }
-        /// add txn to its primary txn's secondary txn list
-        auto *primary_txn = getTransaction(txn->getPrimaryTransactionID())->as<CnchExplicitTransaction>();
-        if (primary_txn) primary_txn->addSecondaryTransaction(txn);
+        /// add txn to its primary txn's secondary txn list, skip query forwarding case of implicit transaction
+        if (txn->getPrimaryTransactionID() != TxnTimestamp::maxTS())
+        {
+            auto *primary_txn = getTransaction(txn->getPrimaryTransactionID())->as<CnchExplicitTransaction>();
+            if (primary_txn) primary_txn->addSecondaryTransaction(txn);
+        }   
         LOG_DEBUG(log, "Created proxy txn {}\n", txn->getTransactionRecord().toString());
         return txn;
     }


### PR DESCRIPTION
### Changelog category <!-- please remove the below items and leave one that you choose -->:
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Auto forwarding sql to host server when having multiple servers in order to utilize the metadata cache. By default, it is disabled, you need to set `enable_auto_query_forwarding=1` to enable it.
- Close https://github.com/ByConity/ByConity/issues/248 and release as a preview(experiment) feature in GA release.
- The design is https://github.com/ByConity/ByConity/issues/208 
