### PR TITLE
fix: fix hang when shutdown

### DIFF
--- a/src/MergeTreeCommon/CnchTopologyMaster.h
+++ b/src/MergeTreeCommon/CnchTopologyMaster.h
@@ -18,6 +18,7 @@
 #include <MergeTreeCommon/CnchServerTopology.h>
 #include <Core/BackgroundSchedulePool.h>
 #include <Interpreters/Context_fwd.h>
+#include <Core/Settings.h>
 
 namespace DB
 {
@@ -55,6 +56,7 @@ private:
     Poco::Logger * log = &Poco::Logger::get("CnchTopologyMaster");
     BackgroundSchedulePool::TaskHolder topology_fetcher;
     std::list<CnchServerTopology> topologies;
+    const Settings settings;
     mutable std::mutex mutex;
 };
 


### PR DESCRIPTION
- Bug Fix

Any application code that acquire Context lock in the scope of BackgroundSchedulePool can cause hang when shutdown.
Explaination:
In the shutdown function of the context
![nZjLqjtOd7](https://github.com/ByConity/ByConity/assets/13962605/58174344-b394-4d5a-b965-5c5f665f0613)
the mutex is acquire first then it start to shutdown BackgroundSchedulePool members.
If the thread that managed by BackgroundSchedulePool is acquire that mutex again. For example like this Topology fetcher
![KJHbZh8ToK](https://github.com/ByConity/ByConity/assets/13962605/7688d683-3719-4251-8795-26cddaed2f9a)
![o5OqWWg4fr](https://github.com/ByConity/ByConity/assets/13962605/68ad75ad-f50a-4278-a8fc-dc732823f69c)

It will causing dead lock

The stacktrace of those two thread here
```
#0  0x00007f0b2e6c1f7c in __lll_lock_wait () from /lib/x86_64-linux-gnu/libpthread.so.0
#1  0x00007f0b2e6bbbb5 in pthread_mutex_lock () from /lib/x86_64-linux-gnu/libpthread.so.0
#2  0x000000000b310336 in pthread_mutex_lock (arg=0x7f0b2c4410a8) at /data01/minh.dao/git/ByConity/src/Common/ThreadFuzzer.cpp:268
#3  0x00000000192a10a9 in std::__1::__libcpp_mutex_lock (__m=0x7f0b2c4410a8) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/__threading_support:405
#4  std::__1::mutex::lock (this=0x7f0b2c4410a8) at /data01/minh.dao/git/ByConity/contrib/libcxx/src/mutex.cpp:33
#5  0x0000000013903e9e in std::__1::lock_guard<std::__1::mutex>::lock_guard (this=<optimized out>, __m=...) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/__mutex_base:91
#6  DB::BackgroundSchedulePoolTaskInfo::deactivate (this=0x7f0b2c441058) at /data01/minh.dao/git/ByConity/src/Core/BackgroundSchedulePool.cpp:79
#7  0x00000000135a23a2 in DB::CnchTopologyMaster::shutDown (this=0x7f0b2afd1418) at /data01/minh.dao/git/ByConity/src/MergeTreeCommon/CnchTopologyMaster.cpp:195
#8  DB::CnchTopologyMaster::~CnchTopologyMaster (this=0x7f0b2afd1418) at /data01/minh.dao/git/ByConity/src/MergeTreeCommon/CnchTopologyMaster.cpp:44
#9  0x0000000013e72aab in std::__1::__shared_count::__release_shared (this=0x7f0b2afd1400) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/memory:2475
#10 std::__1::__shared_weak_count::__release_shared (this=0x7f0b2afd1400) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/memory:2517
#11 std::__1::shared_ptr<DB::CnchTopologyMaster>::~shared_ptr (this=<optimized out>) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/memory:3212
#12 std::__1::shared_ptr<DB::CnchTopologyMaster>::reset (this=0x7f0b2af9c208) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/memory:3308
#13 DB::ContextSharedPart::shutdown (this=0x7f0b2af97b00) at /data01/minh.dao/git/ByConity/src/Interpreters/Context.cpp:520
#14 0x0000000013e61985 in DB::Context::shutdown (this=0x7f0b2c4dc800) at /data01/minh.dao/git/ByConity/src/Interpreters/Context.cpp:3282
#15 0x000000000b36df36 in DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&)::$_6::operator()() const (this=0x7ffccf174af0) at /data01/minh.dao/git/ByConity/programs/server/Server.cpp:1237
#16 basic_scope_guard<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&)::$_6>::invoke() (this=0x7ffccf174af0) at /data01/minh.dao/git/ByConity/base/common/../common/scope_guard.h:94
#17 basic_scope_guard<DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&)::$_6>::~basic_scope_guard() (this=this@entry=0x7ffccf174af0) at /data01/minh.dao/git/ByConity/base/common/../common/scope_guard.h:44
#18 0x000000000b36c777 in DB::Server::main (this=0x7ffccf175060) at /data01/minh.dao/git/ByConity/programs/server/Server.cpp:1874
#19 0x0000000018f5278a in Poco::Util::Application::run (this=0x7ffccf175060) at /data01/minh.dao/git/ByConity/contrib/poco/Util/src/Application.cpp:334
#20 0x000000000b3577c4 in DB::Server::run (this=0x7ffccf175060) at /data01/minh.dao/git/ByConity/programs/server/Server.cpp:478
#21 0x0000000018f645fb in Poco::Util::ServerApplication::run (this=0x7ffccf175060, argc=<optimized out>, argv=0x7f0b2af15da0) at /data01/minh.dao/git/ByConity/contrib/poco/Util/src/ServerApplication.cpp:611
#22 0x000000000b356172 in mainEntryClickHouseServer (argc=3, argv=0x7f0b2af15da0) at /data01/minh.dao/git/ByConity/programs/server/Server.cpp:221
#23 0x000000000b2cbf28 in main (argc_=<optimized out>, argv_=<optimized out>) at /data01/minh.dao/git/ByConity/programs/main.cpp:423
```

```
(gdb) thread 99
[Switching to thread 99 (Thread 0x7f0a081fa700 (LWP 2153569))]
#0  0x00007f0b2e6c1f7c in __lll_lock_wait () from /lib/x86_64-linux-gnu/libpthread.so.0
(gdb) bt
#0  0x00007f0b2e6c1f7c in __lll_lock_wait () from /lib/x86_64-linux-gnu/libpthread.so.0
#1  0x00007f0b2e6bbc26 in pthread_mutex_lock () from /lib/x86_64-linux-gnu/libpthread.so.0
#2  0x000000000b310336 in pthread_mutex_lock (arg=0x7f0b2af97b08) at /data01/minh.dao/git/ByConity/src/Common/ThreadFuzzer.cpp:268
#3  0x00000000192a11c9 in std::__1::__libcpp_recursive_mutex_lock (__m=0x7f0b2af97b08) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/__threading_support:385
#4  std::__1::recursive_mutex::lock (this=0x7f0b2af97b08) at /data01/minh.dao/git/ByConity/contrib/libcxx/src/mutex.cpp:71
#5  0x0000000013e526e3 in std::__1::unique_lock<std::__1::recursive_mutex>::unique_lock (this=<optimized out>, __m=...) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/__mutex_base:119
#6  DB::Context::getLock (this=0x7f0b2c4dc800) at /data01/minh.dao/git/ByConity/src/Interpreters/Context.cpp:649
#7  DB::Context::getSettings (this=0x7f0b2c4dc800) at /data01/minh.dao/git/ByConity/src/Interpreters/Context.cpp:1383
#8  0x00000000135a346f in DB::CnchTopologyMaster::fetchTopologies (this=<optimized out>) at /data01/minh.dao/git/ByConity/src/MergeTreeCommon/CnchTopologyMaster.cpp:100
#9  0x00000000139041de in std::__1::__function::__policy_func<void ()>::operator()() const (this=0x7f0b2c441088) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/functional:2221
#10 std::__1::function<void ()>::operator()() const (this=0x7f0b2c441088) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/functional:2560
#11 DB::BackgroundSchedulePoolTaskInfo::execute (this=0x7f0b2c441058) at /data01/minh.dao/git/ByConity/src/Core/BackgroundSchedulePool.cpp:127
#12 0x0000000013906587 in DB::TaskNotification::execute (this=0x7f0b2afcbc20) at /data01/minh.dao/git/ByConity/src/Core/BackgroundSchedulePool.cpp:40
#13 DB::BackgroundSchedulePool::threadFunction (this=this@entry=0x7f0b2af9bf50) at /data01/minh.dao/git/ByConity/src/Core/BackgroundSchedulePool.cpp:318
#14 0x0000000013906bf7 in DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1::operator()() const (this=<optimized out>) at /data01/minh.dao/git/ByConity/src/Core/BackgroundSchedulePool.cpp:193
#15 std::__1::__invoke_constexpr<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1&>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1&) (__f=...) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/type_traits:3682
#16 std::__1::__apply_tuple_impl<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1&, std::__1::tuple<>&>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1&, std::__1::tuple<>&, std::__1::__tuple_indices<>) (__t=..., __f=...) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/tuple:1415
#17 std::__1::apply<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1&, std::__1::tuple<>&>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1&, std::__1::tuple<>&) (__t=..., __f=...) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/tuple:1424
#18 ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1&&)::{lambda()#1}::operator()() (this=<optimized out>) at /data01/minh.dao/git/ByConity/src/Common/ThreadPool.h:220
#19 std::__1::__invoke<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1&&)::{lambda()#1}&>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1&&) (__f=...) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/type_traits:3676
#20 std::__1::__invoke_void_return_wrapper<void>::__call<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1&&)::{lambda()#1}&>(ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1&&)::{lambda()#1}&) (__args=...) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/__functional_base:348
#21 std::__1::__function::__default_alloc_func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1&&)::{lambda()#1}, void ()>::operator()() (this=<optimized out>) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/functional:1608
#22 std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<ThreadFromGlobalPool::ThreadFromGlobalPool<DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1>(DB::BackgroundSchedulePool::BackgroundSchedulePool(unsigned long, unsigned long, char const*, std::__1::shared_ptr<DB::CpuSet>)::$_1&&)::{lambda()#1}, void ()> >(std::__1::__function::__policy_storage const*) (__buf=<optimized out>) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/functional:2089
#23 0x000000000b308e9f in std::__1::__function::__policy_func<void ()>::operator()() const (this=0x7f0a081ee010) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/functional:2221
#24 std::__1::function<void ()>::operator()() const (this=0x7f0a081ee010) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/functional:2560
#25 ThreadPoolImpl<std::__1::thread>::worker (this=0x7f0b2aeebf80, thread_it=...) at /data01/minh.dao/git/ByConity/src/Common/ThreadPool.cpp:354
#26 0x000000000b30d17a in ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::{lambda()#2}::operator()() const (this=0xfffffffffffffe08) at /data01/minh.dao/git/ByConity/src/Common/ThreadPool.cpp:170
#27 std::__1::__invoke<ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::{lambda()#2}>(ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::{lambda()#2}&&) (__f=...) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/type_traits:3676
#28 std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::{lambda()#2}>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::{lambda()#2}>&, std::__1::__tuple_indices<>) (__t=...) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/thread:280
#29 std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::{lambda()#2}> >(void*) (__vp=<optimized out>) at /data01/minh.dao/git/ByConity/contrib/libcxx/include/thread:291
#30 0x00007f0b2e6b94a4 in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
#31 0x00007f0b2cbf1d0f in clone () from /lib/x86_64-linux-gnu/libc.so.6
```