### PR TITLE
Export s3's virtual host style config

### DIFF
--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -717,19 +717,18 @@ namespace S3
         namespace po = boost::program_options;
         po::options_description s3_opts("s3_opts");
 
-        s3_opts.add_options()("s3.max_redirects", po::value<int>(&max_redirects)->default_value(10)->implicit_value(10), "max_redirects")(
-            "s3.connect_timeout_ms",
-            po::value<int>(&connect_timeout_ms)->default_value(30000)->implicit_value(30000),
-            "connect timeout ms")(
-            "s3.request_timeout_ms",
-            po::value<int>(&request_timeout_ms)->default_value(30000)->implicit_value(30000),
-            "request timeout ms")(
-            "s3.max_connections", po::value<int>(&max_connections)->default_value(200)->implicit_value(200), "max connections")(
-            "s3.region", po::value<String>(&region)->default_value("")->implicit_value(""), "region")(
-            "s3.endpoint", po::value<String>(&endpoint)->required(), "endpoint")(
-            "s3.bucket", po::value<String>(&bucket)->required(), "bucket")("s3.ak_id", po::value<String>(&ak_id)->required(), "ak id")(
-            "s3.ak_secret", po::value<String>(&ak_secret)->required(), "ak secret")(
-            "s3.root_prefix", po::value<String>(&root_prefix)->required(), "root prefix");
+        s3_opts.add_options()
+            ("s3.virtual_host_style", po::value<bool>(&virtual_host_style)->default_value(false)->implicit_value(false), "use virutal host style")
+            ("s3.max_redirects", po::value<int>(&max_redirects)->default_value(10)->implicit_value(10), "max_redirects")
+            ("s3.connect_timeout_ms", po::value<int>(&connect_timeout_ms)->default_value(30000)->implicit_value(30000), "connect timeout ms")
+            ("s3.request_timeout_ms", po::value<int>(&request_timeout_ms)->default_value(30000)->implicit_value(30000), "request timeout ms")
+            ("s3.max_connections", po::value<int>(&max_connections)->default_value(200)->implicit_value(200), "max connections")
+            ("s3.region", po::value<String>(&region)->default_value("")->implicit_value(""), "region")
+            ("s3.endpoint", po::value<String>(&endpoint)->required(), "endpoint")
+            ("s3.bucket", po::value<String>(&bucket)->required(), "bucket")
+            ("s3.ak_id", po::value<String>(&ak_id)->required(), "ak id")
+            ("s3.ak_secret", po::value<String>(&ak_secret)->required(), "ak secret")
+            ("s3.root_prefix", po::value<String>(&root_prefix)->required(), "root prefix");
 
         po::parsed_options opts = po::parse_config_file(ini_file_path.c_str(), s3_opts);
         po::variables_map vm;
@@ -742,6 +741,7 @@ namespace S3
 
     S3Config::S3Config(const Poco::Util::AbstractConfiguration & cfg, const String & cfg_prefix)
     {
+        virtual_host_style = cfg.getBool(cfg_prefix + ".virtual_host_style", false);
         max_redirects = cfg.getInt(cfg_prefix + ".max_redirects", 10);
         connect_timeout_ms = cfg.getInt(cfg_prefix + ".connect_timeout_ms", 10000);
         request_timeout_ms = cfg.getInt(cfg_prefix + ".request_timeout_ms", 30000);
@@ -794,7 +794,8 @@ namespace S3
         client_cfg.maxConnections = max_connections;
         client_cfg.enableTcpKeepAlive = true;
 
-        return S3::ClientFactory::instance().create(client_cfg, false, ak_id, ak_secret, "", {}, false, false);
+        return S3::ClientFactory::instance().create(client_cfg, virtual_host_style,
+            ak_id, ak_secret, "", {}, false, false);
     }
 
 

--- a/src/IO/S3Common.h
+++ b/src/IO/S3Common.h
@@ -108,7 +108,8 @@ public:
         const String& ak_id_, const String& ak_secret_, const String& root_prefix_,
         int connect_timeout_ms_ = 10000, int request_timeout_ms_ = 30000,
         int max_redirects_ = 10, int max_connections_ = 100):
-            max_redirects(max_redirects_), connect_timeout_ms(connect_timeout_ms_),
+            virtual_host_style(false), max_redirects(max_redirects_),
+            connect_timeout_ms(connect_timeout_ms_),
             request_timeout_ms(request_timeout_ms_), max_connections(max_connections_),
             endpoint(endpoint_), region(region_), bucket(bucket_), ak_id(ak_id_),
             ak_secret(ak_secret_), root_prefix(root_prefix_) {}
@@ -119,6 +120,7 @@ public:
 
     std::shared_ptr<Aws::S3::S3Client> create() const;
 
+    bool virtual_host_style;
     int max_redirects;
     int connect_timeout_ms;
     int request_timeout_ms;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->

<!-- If you are doing this for the first time, it's recommended to read the lightweight Contributing to ByConity Documentation https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md guide first. -->

### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Bug Fix

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a new configuration to allow use path style or virtual host style when access s3, since some service only allow use virtual host style

### Documentation entry for user-facing changes
add a new configuration in storage_configuration.disks.{some_disk}.virtual_host_style, it can be set to true or false, default is false, which use path style, set it to true to use virtual host style

example are
```
<storage_configuration>
    <disks>
        <server_s3_disk0>
            <virtual_host_style>true</virtual_host_style>
            ... some other field ...
        </server_s3_disk0>
        ... some other field ...
    </disks>
    ... some other field ...
</storage_configuration>
```

<!---

Add a user-readable short description of the changes that should be added to https://github.com/ByConity/byconity.github.io below.

At a minimum, the following information should be added (but add more as needed).

- Motivation: Why is this function, table engine, etc. useful to ByConity users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
