### PR TITLE
fix TaskGroup::current_task() returns task control in debug mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/ByConity/ByConity
           git -C "$GITHUB_WORKSPACE" submodule sync
-          git -C "$GITHUB_WORKSPACE" submodule update --init --recursive
+          git -C "$GITHUB_WORKSPACE" submodule update --init --recursive --force
           ./build_bin.sh
       - name: run unit tests
         run: |


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->

<!-- If you are doing this for the first time, it's recommended to read the lightweight Contributing to ByConity Documentation https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md guide first. -->

### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- NDEBUG is always defined in bprc and Enable Debug

