### PR TITLE
fix: fix #384

### DIFF
--- a/src/Catalog/FDBClient.cpp
+++ b/src/Catalog/FDBClient.cpp
@@ -20,6 +20,7 @@
 #include <Catalog/FDBError.h>
 #include <Common/Exception.h>
 #include <Catalog/MetastoreFDBImpl.h>
+#include <common/logger_useful.h>
 
 
 namespace DB
@@ -399,29 +400,41 @@ bool Iterator::Next(fdb_error_t & code)
         if (iteration > 1 && !has_more)
             return false;
 
-        if (iteration==1)
+        while (true)
         {
-            batch_future = std::make_shared<FDBFutureRAII>(fdb_transaction_get_range(tr->transaction,
-                FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(reinterpret_cast<const uint8_t*>(start_key_batch.c_str()), start_key_batch.size()),
-                FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(reinterpret_cast<const uint8_t*>(req.end_key.c_str()), req.end_key.size()),
-                req.row_limit, 0, FDB_STREAMING_MODE_LARGE, iteration, 1, req.reverse_order));
-        }
-        else
-        {
-            /// create a new transaction for each get_range to avoid 5 sec timeout
-            tr = std::make_shared<FDB::FDBTransactionRAII>();
-            Catalog::MetastoreFDBImpl::check_fdb_op(client->CreateTransaction(tr));
-            batch_future = std::make_shared<FDBFutureRAII>(fdb_transaction_get_range(tr->transaction,
-                FDB_KEYSEL_FIRST_GREATER_THAN(reinterpret_cast<const uint8_t*>(start_key_batch.c_str()), start_key_batch.size()),
-                FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(reinterpret_cast<const uint8_t*>(req.end_key.c_str()), req.end_key.size()),
-                req.row_limit, 0, FDB_STREAMING_MODE_LARGE, iteration, 1, req.reverse_order));
+            if (iteration==1)
+            {
+                batch_future = std::make_shared<FDBFutureRAII>(fdb_transaction_get_range(tr->transaction,
+                    FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(reinterpret_cast<const uint8_t*>(start_key_batch.c_str()), start_key_batch.size()),
+                    FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(reinterpret_cast<const uint8_t*>(req.end_key.c_str()), req.end_key.size()),
+                    req.row_limit, 0, FDB_STREAMING_MODE_LARGE, iteration, 1, req.reverse_order));
+            }
+            else
+            {
+                batch_future = std::make_shared<FDBFutureRAII>(fdb_transaction_get_range(tr->transaction,
+                    FDB_KEYSEL_FIRST_GREATER_THAN(reinterpret_cast<const uint8_t*>(start_key_batch.c_str()), start_key_batch.size()),
+                    FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(reinterpret_cast<const uint8_t*>(req.end_key.c_str()), req.end_key.size()),
+                    req.row_limit, 0, FDB_STREAMING_MODE_LARGE, iteration, 1, req.reverse_order));
+            }
+
+            code = fdb_future_block_until_ready(batch_future->future);
+            if (code = fdb_future_block_until_ready(batch_future->future); code)
+                return false;
+            if (code = fdb_future_get_error(batch_future->future); code)
+            {
+                // if timeout retry with new transaction
+                if (code == 1031)
+                {
+                    LOG_DEBUG(&Poco::Logger::get("FDBIterator"), "Transaction timeout, create new transaction");
+                    tr = std::make_shared<FDB::FDBTransactionRAII>();
+                    Catalog::MetastoreFDBImpl::check_fdb_op(client->CreateTransaction(tr));
+                    continue;
+                }
+                return false;
+            }
+            break;
         }
 
-        code = fdb_future_block_until_ready(batch_future->future);
-        if (code = fdb_future_block_until_ready(batch_future->future); code)
-            return false;
-        if (code = fdb_future_get_error(batch_future->future); code)
-            return false;
         if (code = fdb_future_get_keyvalue_array(batch_future->future, &batch_kvs, &batch_count, &has_more); code)
             return false;
 

--- a/src/Catalog/FDBClient.cpp
+++ b/src/Catalog/FDBClient.cpp
@@ -423,14 +423,15 @@ bool Iterator::Next(fdb_error_t & code)
             if (code = fdb_future_get_error(batch_future->future); code)
             {
                 // if timeout retry with new transaction
-                if (code == 1031)
+                if (code == FDBError::FDB_transaction_timed_out)
                 {
                     LOG_DEBUG(&Poco::Logger::get("FDBIterator"), "Transaction timeout, create new transaction");
                     tr = std::make_shared<FDB::FDBTransactionRAII>();
                     Catalog::MetastoreFDBImpl::check_fdb_op(client->CreateTransaction(tr));
                     continue;
                 }
-                return false;
+                else
+                    return false;
             }
             break;
         }

--- a/src/Catalog/FDBClient.h
+++ b/src/Catalog/FDBClient.h
@@ -83,13 +83,15 @@ public:
 using FDBTransactionPtr = std::shared_ptr<FDBTransactionRAII>;
 using FDBFuturePtr = std::shared_ptr<FDBFutureRAII>;
 
+class FDBClient;
 class Iterator {
 public:
-    Iterator(FDBTransactionPtr tr_, const ScanRequest & req_);
+    Iterator(FDBClient * client_, FDBTransactionPtr tr_, const ScanRequest & req_);
     bool Next(fdb_error_t & code);
     std::string Key();
     std::string Value();
 private:
+    FDBClient * client = nullptr;
     FDBTransactionPtr tr = nullptr;
     ScanRequest req;
     FDBFuturePtr batch_future = nullptr;

--- a/src/Catalog/MetastoreFDBImpl.h
+++ b/src/Catalog/MetastoreFDBImpl.h
@@ -90,8 +90,8 @@ public:
 
     void close() override {}
 
-private:
     static void check_fdb_op(const fdb_error_t & error_t);
+private:
     /// convert metastore specific error code to Clickhouse error code for processing convenience in upper layer.
     static int toCommonErrorCode(const fdb_error_t & error_t);
 


### PR DESCRIPTION
- Bug Fix
Fix #384

Non optimal fix for transaction timeout issue. We create new transaction for read instead of using old transaction. The implementation inspired from https://github.com/apple/foundationdb/blob/main/bindings/python/fdb/locality.py