### PR TITLE
package Improvement: add build info file into output of the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -643,3 +643,4 @@ add_subdirectory (utils)
 include (cmake/print_include_directories.cmake)
 
 include (cmake/sanitize_target_link_libraries.cmake)
+include (cmake/build_info.cmake)

--- a/cmake/build_info.cmake
+++ b/cmake/build_info.cmake
@@ -1,0 +1,1 @@
+add_custom_target(build_info ALL git rev-parse HEAD > build_info.txt && date >> build_info.txt)


### PR DESCRIPTION
- Build/Testing/Packaging Improvement

Currently for k8s deployment, is it not easy to find out which version the deployment contains. In this PR I will add a build info file into output of the build. This file latter will be added into docker image. Hence we login into the docker image, we can view this file for build information

![image](https://github.com/ByConity/ByConity/assets/13962605/b529f750-f56b-4a03-b1c3-d93684c473f6)
