### PR TITLE
fix coredump in diskcache init

### DIFF
--- a/src/Storages/DiskCache/DiskCacheFactory.cpp
+++ b/src/Storages/DiskCache/DiskCacheFactory.cpp
@@ -37,14 +37,6 @@ void DiskCacheFactory::init(Context & context)
     /// init pool
     IDiskCache::init(context);
 
-
-    // create default cache for all DiskCacheType
-    for(auto type : std::vector<DB::DiskCacheType>{DiskCacheType::File,DiskCacheType::Hive,DiskCacheType::MergeTree}){
-        DiskCacheSettings cache_settings;
-        auto disk_cache = std::make_shared<DiskCacheLRU>(disk_cache_volume,throttler,cache_settings);
-        caches.emplace(type, disk_cache);
-    }
-
     // build disk cache for each type
     if (config.has(DiskCacheSettings::root))
     {
@@ -56,6 +48,15 @@ void DiskCacheFactory::init(Context & context)
             cache_settings.loadFromConfig(config, key);
             auto disk_cache = std::make_shared<DiskCacheLRU>(disk_cache_volume, throttler, cache_settings);
             caches.emplace(stringToDiskCacheType(key), disk_cache);
+        }
+    }
+
+    // create default cache for uninitialized DiskCacheType
+    for(auto type : std::vector<DB::DiskCacheType>{DiskCacheType::File,DiskCacheType::Hive,DiskCacheType::MergeTree}){
+        if(caches.find(type) == caches.end()){
+            DiskCacheSettings cache_settings;
+            auto disk_cache = std::make_shared<DiskCacheLRU>(disk_cache_volume,throttler,cache_settings);
+            caches.emplace(type, disk_cache);
         }
     }
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->

<!-- If you are doing this for the first time, it's recommended to read the lightweight Contributing to ByConity Documentation https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md guide first. -->

### Changelog category <!-- please remove the below items and leave one that you choose -->:

- Bug Fix


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

 If the user configures DiskCache without using the default settings, there is a high probability of encountering a coredump due to division by zero in a multi-threaded initialization scenario.Adding the DiskCache configuration can reproduce the issue with a certain probability.

This issue has already been fixed by me in cnch. It has passed CI testing and cluster testing. It is possible that the relevant personnel have been busy and have not migrated the changes yet. Currently, I am no longer working at ByteDance, but I happened to notice that this problem has not been fixed, so I'm submitting a merge request.

### Documentation entry for user-facing changes

no user-facing  changes happened.

<!---

Add a user-readable short description of the changes that should be added to https://github.com/ByConity/byconity.github.io below.

At a minimum, the following information should be added (but add more as needed).

- Motivation: Why is this function, table engine, etc. useful to ByConity users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
