### PR TITLE
add kinit timeout for runKinit

### DIFF
--- a/src/Access/KerberosInit.h
+++ b/src/Access/KerberosInit.h
@@ -21,6 +21,9 @@
 
 #if USE_KRB5
 
-void kerberosInit(const String & keytab_file, const String & principal, const String & cache_name = "");
+// the default_kinit_timeout is 30min
+constexpr time_t DEFAULT_KINIT_TIMEOUT = 30 * 60;
+
+void kerberosInit(const String & keytab_file, const String & principal, const String & cache_name = "", time_t kinit_timeout = DEFAULT_KINIT_TIMEOUT);
 
 #endif // USE_KRB5

--- a/src/Storages/HDFS/HDFSAuth.cpp
+++ b/src/Storages/HDFS/HDFSAuth.cpp
@@ -42,6 +42,7 @@ HDFSKrb5Params::parseKrb5FromConfig(const Poco::Util::AbstractConfiguration & co
     const String kerberos_keytab = config_key("hadoop_kerberos_keytab");
     const String kerberos_principal = config_key("hadoop_kerberos_principal");
     const String kerberos_ticket_cache_path = config_key("hadoop_security_kerberos_ticket_cache_path");
+    const String kerberos_kinit_timeout = config_key("hadoop_security_kerberos_kinit_timeout");
 
     HDFSKrb5Params krb5_params;
 
@@ -66,6 +67,11 @@ HDFSKrb5Params::parseKrb5FromConfig(const Poco::Util::AbstractConfiguration & co
         krb5_params.hadoop_security_kerberos_ticket_cache_path = config.getString(kerberos_ticket_cache_path);
     }
 
+    if (config.has(kerberos_kinit_timeout))
+    {
+        krb5_params.kinit_timeout = config.getUInt(kerberos_kinit_timeout);
+    }
+
     return krb5_params;
 }
 
@@ -83,7 +89,7 @@ void HDFSKrb5Params::runKinit() const
     if (need_kinit)
     {
         LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "Running KerberosInit");
-        kerberosInit(hadoop_kerberos_keytab, hadoop_kerberos_principal, hadoop_security_kerberos_ticket_cache_path);
+        kerberosInit(hadoop_kerberos_keytab, hadoop_kerberos_principal, hadoop_security_kerberos_ticket_cache_path, kinit_timeout);
         LOG_DEBUG(&Poco::Logger::get("HDFSClient"), "Finished KerberosInit");
     }
 }

--- a/src/Storages/HDFS/HDFSAuth.h
+++ b/src/Storages/HDFS/HDFSAuth.h
@@ -20,6 +20,7 @@
 #if USE_KRB5
 #include <string>
 #include <hdfs/hdfs.h>
+#include <Access/KerberosInit.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <common/types.h>
 
@@ -34,6 +35,8 @@ public:
     String hadoop_kerberos_keytab;
     String hadoop_kerberos_principal;
     String hadoop_security_kerberos_ticket_cache_path;
+
+    time_t kinit_timeout = DEFAULT_KINIT_TIMEOUT;
 
     bool need_kinit{false};
 


### PR DESCRIPTION
add kinit timeout to renew credentials.
default kinit timeout is 30min
add <hadoop_security_kerberos_kinit_timeout> in your server and worker config
```
<!--Default kinit timeout is 30min-->
<hadoop_security_kerberos_kinit_timeout>1800</hadoop_security_kerberos_kinit_timeout>
```
https://github.com/ByConity/ByConity/issues/591