### PR TITLE
fix: check CurrentThread memory tracker not null

### DIFF
--- a/src/WorkerTasks/ManipulationList.cpp
+++ b/src/WorkerTasks/ManipulationList.cpp
@@ -77,7 +77,9 @@ ManipulationListElement::ManipulationListElement(const ManipulationTaskParams & 
     /// so it's parent is required.
     MemoryTracker * query_memory_tracker = CurrentThread::getMemoryTracker();
     MemoryTracker * parent_query_memory_tracker;
-    if (query_memory_tracker->level == VariableContext::Thread && (parent_query_memory_tracker = query_memory_tracker->getParent())
+    if (query_memory_tracker
+        && query_memory_tracker->level == VariableContext::Thread
+        && (parent_query_memory_tracker = query_memory_tracker->getParent())
         && parent_query_memory_tracker != &total_memory_tracker)
     {
         memory_tracker.setOrRaiseHardLimit(parent_query_memory_tracker->getHardLimit());


### PR DESCRIPTION
- Bug Fix

Merge branch 'zema/cnch-2.0-fixNullMemoryTrackerInRpc' into 'cnch-ce-merge'

fix(clickhousech@m-15056756): check CurrentThread memory tracker not null

See merge request dp/ClickHouse!15779
