### PR TITLE
fix: hive orc file bug, should use orc not parquet

### DIFF
--- a/src/Storages/Hive/HiveFile/HiveORCFile.cpp
+++ b/src/Storages/Hive/HiveFile/HiveORCFile.cpp
@@ -190,8 +190,8 @@ SourcePtr HiveORCFile::getReader(const Block & block, const std::shared_ptr<IHiv
     auto arrow_column_to_ch_column = std::make_unique<ArrowColumnToCHColumn>(
         block,
         schema,
-        "Parquet",
-        params->format_settings.parquet.allow_missing_columns,
+        "ORC",
+        params->format_settings.orc.allow_missing_columns,
         params->format_settings.null_as_default);
 
     std::vector<int> column_indices = ORCBlockInputFormat::getColumnIndices(schema, block);


### PR DESCRIPTION

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->

<!-- If you are doing this for the first time, it's recommended to read the lightweight Contributing to ByConity Documentation https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md guide first. -->

### Changelog category <!-- please remove the below items and leave one that you choose -->:
- New Feature
- Bug Fix
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Other
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

fix:  Constructing **arrow_column_to_ch_column** object should use **ORC** parameters instead of **Parquet** parameters in the getReader method of **HiveORCFile.cpp**

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---

Add a user-readable short description of the changes that should be added to https://github.com/ByConity/byconity.github.io below.

At a minimum, the following information should be added (but add more as needed).

- Motivation: Why is this function, table engine, etc. useful to ByConity users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
