### PR TITLE
Recreate transaction if transaction too old when scan

### DIFF
--- a/src/Catalog/FDBClient.cpp
+++ b/src/Catalog/FDBClient.cpp
@@ -446,9 +446,10 @@ bool Iterator::Next(fdb_error_t & code)
             if (code = fdb_future_get_error(batch_future->future); code)
             {
                 // if timeout retry with new transaction
-                if (code == FDBError::FDB_transaction_timed_out)
+                if (code == FDBError::FDB_transaction_too_old
+                    || code == FDBError::FDB_transaction_timed_out)
                 {
-                    LOG_DEBUG(&Poco::Logger::get("FDBIterator"), "Transaction timeout, create new transaction");
+                    LOG_DEBUG(&Poco::Logger::get("FDBIterator"), "Transaction timeout or too old, create new transaction");
                     tr = std::make_shared<FDB::FDBTransactionRAII>();
                     Catalog::MetastoreFDBImpl::check_fdb_op(client->CreateTransaction(tr));
                     continue;


### PR DESCRIPTION
### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Bug Fix

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

FDB re-create transaction if transaction is too old when scanning