### PR TITLE
revert WriteBufferFromFile change

### DIFF
--- a/src/IO/WriteBufferFromFile.h
+++ b/src/IO/WriteBufferFromFile.h
@@ -50,11 +50,6 @@ public:
     /// Close file before destruction of object.
     void close();
 
-    void finalize() override 
-    {
-        sync();
-    }
-
     std::string getFileName() const override
     {
         return file_name;


### PR DESCRIPTION
Sync on finalize  may cause slow writes to the tmp part.
from https://github.com/ByConity/ByConity/commit/cae95d5a02c428644bca173b4b742b5eda140424