### PR TITLE
Init KVStorage and getLock later

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1012,7 +1012,6 @@ int Server::main(const std::vector<std::string> & /*args*/)
         /* already_loaded = */ false);  /// Reload it right now (initial loading)
 
     auto & access_control = global_context->getAccessControlManager();
-    access_control.addKVStorage(global_context);
     if (config().has("custom_settings_prefixes"))
         access_control.setCustomSettingsPrefixes(config().getString("custom_settings_prefixes"));
 
@@ -1037,6 +1036,7 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
     /// Initialize access storages.
     access_control.addStoragesFromMainConfig(config(), config_path, [&] { return global_context->getZooKeeper(); });
+    access_control.addKVStorage(global_context);
 
     /// Reload config in SYSTEM RELOAD CONFIG query.
     global_context->setConfigReloadCallback([&]()

--- a/src/Access/AccessControlManager.cpp
+++ b/src/Access/AccessControlManager.cpp
@@ -384,8 +384,8 @@ void AccessControlManager::addStoragesFromMainConfig(
     // if (!disk_storage_dir.empty())
     //     addDiskStorage(disk_storage_dir);
 
-    // if (has_user_directories)
-    //     addStoragesFromUserDirectoriesConfig(config, "user_directories", config_dir, dbms_dir, include_from_path, get_zookeeper_function);
+    if (has_user_directories)
+        addStoragesFromUserDirectoriesConfig(config, "user_directories", config_dir, dbms_dir, include_from_path, get_zookeeper_function);
 }
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->

<!-- If you are doing this for the first time, it's recommended to read the lightweight Contributing to ByConity Documentation https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md guide first. -->

### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Bug Fix


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

- Init KVStorage later in Server.cpp to prevent null pointer acesses
- getLock in setUser after logging in as AccessControlManager has long running IO ops. This is to prevent deadlocks

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---

Add a user-readable short description of the changes that should be added to https://github.com/ByConity/byconity.github.io below.

At a minimum, the following information should be added (but add more as needed).

- Motivation: Why is this function, table engine, etc. useful to ByConity users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
