### PR TITLE
fix connectionpool deadlock

### DIFF
--- a/src/Common/PoolBase.h
+++ b/src/Common/PoolBase.h
@@ -180,7 +180,7 @@ public:
                 return Entry(allocObject());
 
             Stopwatch blocked;
-            if (timeout < 0)
+            if (timeout <= 0)
             {
                 LOG_INFO(log, "No free connections in pool. Waiting indefinitely.");
                 available.wait(lock);


### PR DESCRIPTION
when timeout equal zero, std::condition_variable will return immediately【lock will not unlock】, this  will lead to connectionpool deadlock. This will fix issue #787 