### PR TITLE
fix bug: checksum_ptr will not be set when part checksum exists in central cache

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -636,6 +636,8 @@ protected:
 
     virtual void removeImpl(bool keep_shared_data) const;
 
+    virtual void SetChecksumsPtrIfNeed(const ChecksumsPtr & checksums);
+
 private:
     /// In compact parts order of columns is necessary
     NameToNumber column_name_to_position;

--- a/src/Storages/MergeTree/MergeTreeDataPartCNCH.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartCNCH.cpp
@@ -628,11 +628,7 @@ IMergeTreeDataPart::ChecksumsPtr MergeTreeDataPartCNCH::loadChecksums([[maybe_un
 
     checksums = loadChecksumsForPart(true);
 
-    if (storage.getSettings()->enable_persistent_checksum || is_temp || isProjectionPart())
-    {
-        std::lock_guard lock(checksums_mutex);
-        checksums_ptr = checksums;
-    }
+    SetChecksumsPtrIfNeed(checksums);
 
     /// store in disk cache
     if (enableDiskCache())


### PR DESCRIPTION
fix bug: checksum_ptr will not be set when part checksum exists in central cache

this will cause central cache read amplified and fix issue #833 