### PR TITLE
feat: add brpc_data_parts_timeout_ms parameters to control part data sending timeout

### DIFF
--- a/src/CloudServices/CnchWorkerClient.cpp
+++ b/src/CloudServices/CnchWorkerClient.cpp
@@ -205,7 +205,7 @@ brpc::CallId CnchWorkerClient::preloadDataParts(
     auto * response = new Protos::PreloadDataPartsResp();
     /// adjust the timeout to prevent timeout if there are too many parts to send,
     const auto & settings = context->getSettingsRef();
-    auto send_timeout = std::max(settings.max_execution_time.value.totalMilliseconds() >> 1, 30 * 1000L);
+    auto send_timeout = std::max(settings.max_execution_time.value.totalMilliseconds() >> 1, settings.brpc_data_parts_timeout_ms.totalMilliseconds());
     cntl->set_timeout_ms(send_timeout);
 
     auto call_id = cntl->call_id();
@@ -227,7 +227,7 @@ brpc::CallId CnchWorkerClient::dropPartDiskCache(
     Protos::DropPartDiskCacheResp response;
 
     const auto & settings = context->getSettingsRef();
-    auto send_timeout = std::max(settings.max_execution_time.value.totalMilliseconds() >> 1, 30 * 1000L);
+    auto send_timeout = std::max(settings.max_execution_time.value.totalMilliseconds() >> 1, settings.brpc_data_parts_timeout_ms.totalMilliseconds());
     cntl.set_timeout_ms(send_timeout);
 
     request.set_txn_id(txn_id);
@@ -276,7 +276,7 @@ brpc::CallId CnchWorkerClient::sendQueryDataParts(
     auto * response = new Protos::SendDataPartsResp();
     /// adjust the timeout to prevent timeout if there are too many parts to send,
     const auto & settings = context->getSettingsRef();
-    auto send_timeout = std::max(settings.max_execution_time.value.totalMilliseconds() >> 1, 30 * 1000L);
+    auto send_timeout = std::max(settings.max_execution_time.value.totalMilliseconds() >> 1, settings.brpc_data_parts_timeout_ms.totalMilliseconds());
     cntl->set_timeout_ms(send_timeout);
 
     auto call_id = cntl->call_id();
@@ -370,8 +370,8 @@ brpc::CallId CnchWorkerClient::sendResources(
 
     brpc::Controller * cntl = new brpc::Controller;
     /// send_timeout refers to the time to send resource to worker
-    /// If max_execution_time is not set, the send_timeout will be set to 30s
-    auto send_timeout_ms = max_execution_time ? max_execution_time * 1000L : 30 * 1000L;
+    /// If max_execution_time is not set, the send_timeout will be set to brpc_data_parts_timeout_ms
+    auto send_timeout_ms = max_execution_time ? max_execution_time * 1000L : settings.brpc_data_parts_timeout_ms.totalMilliseconds();
     cntl->set_timeout_ms(send_timeout_ms);
     const auto call_id = cntl->call_id();
     auto * response = new Protos::SendResourcesResp();

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -1629,6 +1629,7 @@ enum PreloadLevelSettings : UInt64
     M(Bool, drop_vw_disk_cache, false, "if drop the all disk cache of vw even pass one table.", 0) \
     M(Bool, force_grouping_standard_compatibility, true, "Make GROUPING function to return 1 when argument is not used as an aggregation key", 0) \
     M(Bool, disable_optimize_final, true, "Disable optimize final command", 0) \
+    M(Milliseconds, brpc_data_parts_timeout_ms, 30000, "Timeout for transmitting data parts in brpc", 0) \
     /** Settings for hive */ \
     M(Bool, use_hive_metastore_filter, true, "", 0) \
     M(Bool, use_hive_cluster_key_filter, true, "", 0) \


### PR DESCRIPTION

### Changelog category
- New Feature


### Changelog entry
Add a parameter to control the brpc timeout for data parts
#881 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---

Add a user-readable short description of the changes that should be added to https://github.com/ByConity/byconity.github.io below.

At a minimum, the following information should be added (but add more as needed).

- Motivation: Why is this function, table engine, etc. useful to ByConity users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
