### PR TITLE
fix too many bytes error on fdb batch write

### DIFF
--- a/src/Catalog/MetastoreCommon.h
+++ b/src/Catalog/MetastoreCommon.h
@@ -79,6 +79,7 @@ struct BatchCommitRequest
     void AddPut(const SinglePutRequest & put) { puts.emplace_back(put); }
     void AddDelete(const std::string & del) { deletes.emplace_back(del); }
     void AddDelete(const std::string & delkey, const std::string & expected) { deletes.emplace_back(delkey, "", expected); }
+    void ClearDelete() { deletes.clear(); }
     void SetTimeout(uint32_t time_out) { commit_timeout_ms = time_out; }
     bool isEmpty() { return puts.empty() && deletes.empty(); }
 


### PR DESCRIPTION

There was a bug we noticed when Daemon manager was trying to clean up a lot of transactions:
```
2023.11.22 14:06:22.057689 [ 6659 ] {} <Error> TxnGCThread: Error occurs during daemon TxnGCThread execution: Code: 2101, e.displayText() = DB::Exception: FDB error : Transaction exceeds byte limit SQLSTATE: HY000, Stack trace (when copying this message, always include the lines below):

0. Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x1e26f752 in /opt/byconity/bin/clickhouse
1. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0xd4d4200 in /opt/byconity/bin/clickhouse
2. DB::Catalog::MetastoreFDBImpl::check_fdb_op(int const&) @ 0x177a6a8d in /opt/byconity/bin/clickhouse
3. DB::Catalog::MetastoreFDBImpl::batchWrite(DB::Catalog::BatchCommitRequest const&, DB::Catalog::BatchCommitResponse&) @ 0x177a7bdd in /opt/byconity/bin/clickhouse
4. DB::Catalog::MetastoreProxy::removeTransactionRecords(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::vector<DB::TxnTimestamp, std::__1::allocator<DB::TxnTimestamp> > const&) @ 0x177bead6 in /opt/byconity/bin/clickhouse
5. DB::Catalog::Catalog::removeTransactionRecords(std::__1::vector<DB::TxnTimestamp, std::__1::allocator<DB::TxnTimestamp> > const&) @ 0x1774270a in /opt/byconity/bin/clickhouse
6. void std::__1::__function::__policy_invoker<void ()>::__call_impl<std::__1::__function::__default_alloc_func<DB::DaemonManager::DaemonJobTxnGC::cleanTxnRecords(std::__1::vector<DB::TransactionRecord, std::__1::allocator<DB::TransactionRecord> > const&)::$_1, void ()> >(std::__1::__function::__policy_storage const*) @ 0x19fb6018 in /opt/byconity/bin/clickhouse
7. void std::__1::__invoke_void_return_wrapper<void>::__call<createExceptionHandledJob(std::__1::function<void ()>, DB::ExceptionHandler&)::'lambda'()&>(createExceptionHandledJob(std::__1::function<void ()>, DB::ExceptionHandler&)::'lambda'()&) @ 0xd6644f1 in /opt/byconity/bin/clickhouse
8. ThreadPoolImpl<ThreadFromGlobalPool>::worker(std::__1::__list_iterator<ThreadFromGlobalPool, void*>) @ 0xd5178be in /opt/byconity/bin/clickhouse
9. ThreadFromGlobalPool::ThreadFromGlobalPool<void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()>(void&&, void ThreadPoolImpl<ThreadFromGlobalPool>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()&&...)::'lambda'()::operator()() @ 0xd519708 in /opt/byconity/bin/clickhouse
10. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0xd51449f in /opt/byconity/bin/clickhouse
11. void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(std::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda0'()> >(void*) @ 0xd51877a in /opt/byconity/bin/clickhouse
12. start_thread @ 0x7ea7 in /lib/x86_64-linux-gnu/libpthread-2.31.so
13. clone @ 0xfca2f in /lib/x86_64-linux-gnu/libc-2.31.so
 (version 21.8.7.1)

```
FoundationDB lets the transaction be at most 10M bytes. This PR aims to fix it. We locally tested the build and no error was thrown after this. Im not sure where to provide 10M constant so any feedback is welcome :) 

### Changelog category
- Bug Fix


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

There was no limit to FoundationDB batchWrite string, which was hitting the transaction limits of fdb. This PR introduces sub-batching to remain within 10M bytes length transaction limits. 

