### PR TITLE
change log level from error to info when remove not empty directory partition remove

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataPartCNCH.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartCNCH.cpp
@@ -1103,7 +1103,7 @@ void MergeTreeDataPartCNCH::removeImpl(bool keep_shared_data) const
             return;
         }
         /// Recursive directory removal does many excessive "stat" syscalls under the hood.
-        LOG_ERROR(
+        LOG_INFO(
             storage.log,
             "Cannot quickly remove directory {} by removing files; fallback to recursive removal. Reason: {}",
             fullPath(disk, path_on_disk),
@@ -1124,7 +1124,7 @@ void MergeTreeDataPartCNCH::projectionRemove(const String & parent_to, bool) con
     catch (...)
     {
         /// Recursive directory removal does many excessive "stat" syscalls under the hood.
-        LOG_ERROR(
+        LOG_INFO(
             storage.log,
             "Cannot quickly remove directory {} by removing files; fallback to recursive removal. Reason: {}",
             fullPath(disk, projection_path_on_disk),


### PR DESCRIPTION
threre are too many error message in s3 partition remove logic:
1. try remove directory first
2. if directory is empty,  ends successfully
3. if directory is not empty, print error message , fallback to normal recursive remove

step 3 should print info message instead of error message

this will fix #917 