### PR TITLE
clean worker resource syncly.

### DIFF
--- a/src/CloudServices/CnchWorkerServiceImpl.cpp
+++ b/src/CloudServices/CnchWorkerServiceImpl.cpp
@@ -717,11 +717,18 @@ void CnchWorkerServiceImpl::removeWorkerResource(
     Protos::RemoveWorkerResourceResp * response,
     google::protobuf::Closure * done)
 {
-    SUBMIT_THREADPOOL({
+    brpc::ClosureGuard done_guard(done);
+    try
+    {
         auto session = getContext()->acquireNamedCnchSession(request->txn_id(), {}, true);
         /// remove resource in worker
         session->release();
-    })
+    }
+    catch (...)
+    {
+        tryLogCurrentException(log, __PRETTY_FUNCTION__);
+        RPCHelpers::handleException(response->mutable_exception());
+    }
 }
 
 #if defined(__clang__)


### PR DESCRIPTION
Previously the worker resource is cleaned by background task and rpc is returned before the task is done. There could introduce data race for worker resource, resulting in "parts already exists" or "table not found" when sending server resource.