### PR TITLE
fix: add lru cache for invert index to avoid oom AND disable String to Array(XXX) CAST at ddl modify column Scenario

### DIFF
--- a/src/QueryPlan/TableWriteStep.cpp
+++ b/src/QueryPlan/TableWriteStep.cpp
@@ -66,7 +66,7 @@ BlockOutputStreams TableWriteStep::createOutputStream(
             out = target_table->write(nullptr, metadata_snapshot, settings.context);
         else
             out = std::make_shared<PushingToViewsBlockOutputStream>(
-                target_table, metadata_snapshot, settings.context, nullptr, no_destination);
+                target_table, metadata_snapshot, settings.context, ASTPtr(), no_destination);
 
         /// Note that we wrap transforms one on top of another, so we write them in reverse of data processing order.
 

--- a/src/Storages/StorageCnchMergeTree.cpp
+++ b/src/Storages/StorageCnchMergeTree.cpp
@@ -1036,18 +1036,11 @@ std::pair<String, const Cluster::ShardInfo *> StorageCnchMergeTree::prepareLocal
     return std::make_pair(local_table_name, write_shard_ptr);
 }
 
-BlockOutputStreamPtr
-StorageCnchMergeTree::write(const ASTPtr & query, const StorageMetadataPtr & metadata_snapshot, ContextPtr local_context)
+BlockOutputStreamPtr StorageCnchMergeTree::write(const ASTPtr &, const StorageMetadataPtr & metadata_snapshot, ContextPtr local_context)
 {
     bool enable_staging_area = metadata_snapshot->hasUniqueKey() && bool(local_context->getSettingsRef().enable_staging_area_for_write);
     if (enable_staging_area)
         LOG_DEBUG(log, "enable staging area for write");
-
-    auto modified_query_ast = query->clone();
-    auto & insert_query = modified_query_ast->as<ASTInsertQuery &>();
-
-    if (insert_query.table_id.database_name.empty())
-        insert_query.table_id.database_name = local_context->getCurrentDatabase();
 
     return std::make_shared<CloudMergeTreeBlockOutputStream>(*this, metadata_snapshot, local_context, enable_staging_area);
 }


### PR DESCRIPTION
fix: add lru cache for invert index to avoid oom AND disable String to Array(XXX) CAST at ddl modify column Scenario