### PR TITLE
fix: throw exception when DROP PARTITION WHERE contains no partition key

### DIFF
--- a/src/DataStreams/PushingToViewsBlockOutputStream.cpp
+++ b/src/DataStreams/PushingToViewsBlockOutputStream.cpp
@@ -143,6 +143,7 @@ PushingToViewsBlockOutputStream::PushingToViewsBlockOutputStream(
         if (dynamic_cast<const StorageView *>(view_table.get()))
            continue;
 
+        Block output_header;
         if (auto * materialized_view = dynamic_cast<StorageMaterializedView *>(view_table.get()))
         {
             addTableLock(
@@ -166,6 +167,7 @@ PushingToViewsBlockOutputStream::PushingToViewsBlockOutputStream(
                 auto target_metadata_snapshot = cnch_target_table->getInMemoryMetadataPtr();
                 bool enable_staging_area = target_metadata_snapshot->hasUniqueKey() && bool(getContext()->getSettingsRef().enable_staging_area_for_write);
                 out = std::make_shared<CloudMergeTreeBlockOutputStream>(*cnch_target_table, target_metadata_snapshot, insert_context, enable_staging_area);
+                output_header = target_metadata_snapshot->getSampleBlockNonMaterialized(true);
             }
             else
             {
@@ -179,13 +181,12 @@ PushingToViewsBlockOutputStream::PushingToViewsBlockOutputStream(
                 auto header = InterpreterSelectQuery(query, select_context, SelectQueryOptions().analyze())
                     .getSampleBlock();
 
-                /// Insert only columns returned by select.
+                /// Select columns without materialized columns and columns function of uniq merge tree.
                 auto list = std::make_shared<ASTExpressionList>();
-                const auto & target_table_columns = target_metadata_snapshot->getColumns();
+                const auto & target_table_columns = target_metadata_snapshot->getSampleBlockNonMaterialized(true);
                 for (const auto & column : header)
                 {
-                    /// But skip columns which storage doesn't have.
-                    if (target_table_columns.hasPhysical(column.name))
+                    if (target_table_columns.has(column.name))
                         list->children.emplace_back(std::make_shared<ASTIdentifier>(column.name));
                 }
 
@@ -194,16 +195,22 @@ PushingToViewsBlockOutputStream::PushingToViewsBlockOutputStream(
                 InterpreterInsertQuery interpreter(insert_query_ptr, insert_context);
                 BlockIO io = interpreter.execute();
                 out = io.out;
+                output_header = out->getHeader();
             }
         }
         else if (dynamic_cast<const StorageLiveView *>(view_table.get()))
+        {
             out = std::make_shared<PushingToViewsBlockOutputStream>(
                 view_table, dependent_metadata_snapshot, insert_context, ASTPtr(), true);
+            output_header = dependent_metadata_snapshot->getSampleBlockNonMaterialized(true);
+        }
         else
-            out = std::make_shared<PushingToViewsBlockOutputStream>(
-                view_table, dependent_metadata_snapshot, insert_context, ASTPtr());
+        {
+            out = std::make_shared<PushingToViewsBlockOutputStream>(view_table, dependent_metadata_snapshot, insert_context, ASTPtr());
+            output_header = dependent_metadata_snapshot->getSampleBlockNonMaterialized(true);
+        }
 
-        views.emplace_back(ViewInfo{std::move(query), database_table, std::move(out), nullptr, 0});
+        views.emplace_back(ViewInfo{std::move(query), database_table, std::move(out), nullptr, 0, output_header});
     }
 
     /// Do not push to destination table if the flag is set
@@ -532,7 +539,7 @@ void PushingToViewsBlockOutputStream::process(const Block & block, ViewInfo & vi
             /// and two-level aggregation is triggered).
             in = std::make_shared<SquashingBlockInputStream>(
                     in, getContext()->getSettingsRef().min_insert_block_size_rows, getContext()->getSettingsRef().min_insert_block_size_bytes);
-            in = std::make_shared<ConvertingBlockInputStream>(in, view.out->getHeader(), ConvertingBlockInputStream::MatchColumnsMode::Name);
+            in = std::make_shared<ConvertingBlockInputStream>(in, view.output_header ? view.output_header : view.out->getHeader(), ConvertingBlockInputStream::MatchColumnsMode::Name);
         }
         else
             in = std::make_shared<OneBlockInputStream>(block);

--- a/src/DataStreams/PushingToViewsBlockOutputStream.h
+++ b/src/DataStreams/PushingToViewsBlockOutputStream.h
@@ -72,6 +72,7 @@ private:
         BlockOutputStreamPtr out;
         std::exception_ptr exception;
         UInt64 elapsed_ms = 0;
+        Block output_header;
     };
 
     std::vector<ViewInfo> views;

--- a/src/Functions/map.cpp
+++ b/src/Functions/map.cpp
@@ -1034,9 +1034,12 @@ public:
         auto res = stream->read();
         if (res)
         {
-            Field field;
-            res.getByName("keys").column->get(0, field);
-            return result_type->createColumnConst(input_rows_count, field)->convertToFullColumnIfConst();
+            // TODO(shiyuze): maybe add a new function to get result in different rows, just like arrayJoin(getMapKeys(xxx))
+
+            /// Total map key number in result may exceed max_array_size_as_field (for example, 
+            /// each pratition or bucket has different key sets), so we need to avoid calling 
+            /// ColumnArray::[] or ColumnArray::get() to get array as a Field here.
+            return ColumnConst::create(res.getByName("keys").column, input_rows_count)->convertToFullColumnIfConst();
         }
         else
         {

--- a/src/Storages/MergeTree/CloudMergeTreeBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/CloudMergeTreeBlockOutputStream.cpp
@@ -401,7 +401,7 @@ CloudMergeTreeBlockOutputStream::FilterInfo CloudMergeTreeBlockOutputStream::ded
 {
     if (!metadata_snapshot->hasUniqueKey())
         return FilterInfo{};
-
+    
     const ColumnWithTypeAndName * version_column = nullptr;
     if (metadata_snapshot->hasUniqueKey() && storage.merging_params.hasExplicitVersionColumn())
         version_column = &block.getByName(storage.merging_params.version_column);

--- a/tests/queries/4_cnch_stateless/01001_alter_drop_partition.reference
+++ b/tests/queries/4_cnch_stateless/01001_alter_drop_partition.reference
@@ -1,0 +1,12 @@
+------ WRONG PARTITION ID, DROP NOTHING ------
+1
+------ DROP PARTITION ID 20240101-1 ------
+0
+------ WRONG PARTITION, DROP NOTHING ------
+4
+------ DROP PARTITION (20240101, 2) ------
+3
+------ FINAL STATE ------
+0
+3
+4

--- a/tests/queries/4_cnch_stateless/01001_alter_drop_partition.sql
+++ b/tests/queries/4_cnch_stateless/01001_alter_drop_partition.sql
@@ -1,0 +1,29 @@
+DROP TABLE IF EXISTS t_alter_partition;
+
+CREATE TABLE t_alter_partition(p DateTime, k Int32, m Int32) ENGINE = CnchMergeTree PARTITION BY (toDate(p), k) ORDER BY m;
+
+INSERT INTO t_alter_partition SELECT '2024-01-01 11:11:11', number, number from numbers(5);
+SYSTEM START MERGES t_alter_partition;
+
+SELECT '------ WRONG PARTITION ID, DROP NOTHING ------';
+ALTER TABLE t_alter_partition DROP PARTITION ID '2024-01-01-1';
+SELECT count() FROM t_alter_partition WHERE k = 1;
+
+SELECT '------ DROP PARTITION ID 20240101-1 ------';
+ALTER TABLE t_alter_partition DROP PARTITION ID '20240101-1';
+SELECT count() FROM t_alter_partition WHERE k = 1;
+
+SELECT '------ WRONG PARTITION, DROP NOTHING ------';
+ALTER TABLE t_alter_partition DROP PARTITION ('20240101', 6);
+SELECT count() FROM t_alter_partition;
+
+SELECT '------ DROP PARTITION (20240101, 2) ------';
+ALTER TABLE t_alter_partition DROP PARTITION ('20240101', 2);
+SELECT count() FROM t_alter_partition;
+
+ALTER TABLE t_alter_partition DROP PARTITION WHERE m = 5; -- { serverError 47 }
+
+SELECT '------ FINAL STATE ------';
+SELECT k FROM t_alter_partition ORDER BY k;
+
+DROP TABLE t_alter_partition;


### PR DESCRIPTION
fix: throw exception when DROP PARTITION WHERE contains no partition key