### PR TITLE
chore: fix util script

### DIFF
--- a/utils/create_pr/create_pr.sh
+++ b/utils/create_pr/create_pr.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source ./proc_title.sh
+source $(dirname "$0")/proc_title.sh
 
 if [ -z "$1" ]; then
     BRANCH=$(git branch --show-current)


### PR DESCRIPTION
chore: fix util script
`create_pr.sh` script execute failed when executed from directories different than the directory contains the script