### PR TITLE
fix: keep grace hash join when exchange type is broadcast

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -1443,6 +1443,7 @@ enum PreloadLevelSettings : UInt64
     M(UInt64, grace_hash_join_max_buckets, 1024, "Limit on the number of grace hash join buckets", 0) \
     M(UInt64, grace_hash_join_left_side_parallel, 1, "Initial number of grace hash join left side parallel", 0) \
     M(UInt64, grace_hash_join_read_result_block_size, 65536, "Initial number of grace hash join left side parallel", 0) \
+    M(Bool, use_grace_hash_only_repartition, false, "Only use grace hash join when exchange type is repartition", 0) \
     M(UInt64, filesystem_cache_max_download_size, (128UL * 1024 * 1024 * 1024), "Max remote filesystem cache size that can be downloaded by a single query", 0) \
     M(Bool, skip_download_if_exceeds_query_cache, true, "Skip download from remote filesystem if exceeds query cache size", 0) \
     \


### PR DESCRIPTION
fix: keep grace hash join when exchange type is broadcast