### PR TITLE
fix: [cp] Undo buffer use reversed transaction id to avoid write increment keys to bytekv

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1059,6 +1059,9 @@ int Server::main(const std::vector<std::string> & /*args*/)
 
                 global_context->setVWCustomizedSettings(std::make_shared<VWCustomizedSettings>(config));
             }
+
+            if (auto catalog = global_context->tryGetCnchCatalog())
+                catalog->loadFromConfig("catalog_service", *config);
         },
         /* already_loaded = */ false);  /// Reload it right now (initial loading)
 

--- a/src/Catalog/Catalog.cpp
+++ b/src/Catalog/Catalog.cpp
@@ -517,6 +517,13 @@ namespace Catalog
         return parseQuery(parser, begin, end, "", 0, 0);
     }
 
+    void Catalog::loadFromConfig(const String & config_elem, const Poco::Util::AbstractConfiguration & config)
+    {
+        if (!config.has(config_elem))
+            return;
+        settings.loadFromConfig(config_elem + ".settings", config);
+    }
+
     Catalog::Catalog(Context & _context, const MetastoreConfig & config, String _name_space) : context(_context), name_space(_name_space)
     {
         runWithMetricSupport(
@@ -535,7 +542,6 @@ namespace Catalog
                 }
 
                 meta_proxy = std::make_shared<MetastoreProxy>(config);
-                max_commit_size_one_batch = context.getSettingsRef().catalog_max_commit_size;
                 /// Support set a custom topology key
                 if (config.topology_key.empty())
                     topology_key = name_space;
@@ -2298,7 +2304,7 @@ namespace Catalog
             assertLocalServerThrowIfNot(storage);
 
         // commit parts and delete bitmaps in one batch if the size is small.
-        if (total_parts_number + delete_bitmaps.size() + total_staged_parts_num < max_commit_size_one_batch)
+        if (total_parts_number + delete_bitmaps.size() + total_staged_parts_num < settings.max_commit_size_one_batch)
         {
             commit_in_batch(
                 {0,
@@ -2318,49 +2324,49 @@ namespace Catalog
         {
             // commit data parts first
             size_t batch_count{0};
-            while (batch_count + max_commit_size_one_batch < total_parts_number)
+            while (batch_count + settings.max_commit_size_one_batch < total_parts_number)
             {
                 commit_in_batch(
                     {batch_count,
-                     batch_count + max_commit_size_one_batch,
+                     batch_count + settings.max_commit_size_one_batch,
                      0,
                      0,
                      0,
                      0,
                      batch_count,
-                     batch_count + max_commit_size_one_batch,
+                     batch_count + settings.max_commit_size_one_batch,
                      0,
                      0,
                      0,
                      0});
-                batch_count += max_commit_size_one_batch;
+                batch_count += settings.max_commit_size_one_batch;
             }
             commit_in_batch({batch_count, total_parts_number, 0, 0, 0, 0, batch_count, total_parts_number, 0, 0, 0, 0});
 
             // then commit delete bitmap
             batch_count = 0;
-            while (batch_count + max_commit_size_one_batch < delete_bitmaps.size())
+            while (batch_count + settings.max_commit_size_one_batch < delete_bitmaps.size())
             {
                 commit_in_batch(
                     {0,
                      0,
                      batch_count,
-                     batch_count + max_commit_size_one_batch,
+                     batch_count + settings.max_commit_size_one_batch,
                      0,
                      0,
                      0,
                      0,
                      batch_count,
-                     batch_count + max_commit_size_one_batch,
+                     batch_count + settings.max_commit_size_one_batch,
                      0,
                      0});
-                batch_count += max_commit_size_one_batch;
+                batch_count += settings.max_commit_size_one_batch;
             }
             commit_in_batch({0, 0, batch_count, total_deleted_bitmaps_number, 0, 0, 0, 0, batch_count, total_deleted_bitmaps_number, 0, 0});
 
             // then commit staged parts
             batch_count = 0;
-            while (batch_count + max_commit_size_one_batch < total_staged_parts_num)
+            while (batch_count + settings.max_commit_size_one_batch < total_staged_parts_num)
             {
                 commit_in_batch(
                     {0,
@@ -2368,14 +2374,14 @@ namespace Catalog
                      0,
                      0,
                      batch_count,
-                     batch_count + max_commit_size_one_batch,
+                     batch_count + settings.max_commit_size_one_batch,
                      0,
                      0,
                      0,
                      0,
                      batch_count,
-                     batch_count + max_commit_size_one_batch});
-                batch_count += max_commit_size_one_batch;
+                     batch_count + settings.max_commit_size_one_batch});
+                batch_count += settings.max_commit_size_one_batch;
             }
             commit_in_batch({0, 0, 0, 0, batch_count, total_staged_parts_num, 0, 0, 0, 0, batch_count, total_staged_parts_num});
         }
@@ -3505,7 +3511,7 @@ namespace Catalog
                 bool need_invalid_part_cache = context.getPartCacheManager() && !commit_data.data_parts.empty();
                 bool need_invalid_bitmap_cache = context.getPartCacheManager() && !commit_data.delete_bitmaps.empty();
                 /// drop in batch if the number of drop keys greater than max_drop_size_one_batch
-                if (drop_keys.size() > max_drop_size_one_batch)
+                if (drop_keys.size() > settings.max_drop_size_one_batch)
                 {
                     size_t batch_count{0};
                     const size_t mark1 = commit_data.data_parts.size();
@@ -3515,9 +3521,9 @@ namespace Catalog
                     {
                         meta_proxy->multiDrop(Strings{
                             drop_keys.begin() + batch_count,
-                            drop_keys.begin() + std::min(batch_count + max_drop_size_one_batch, drop_keys.size())});
+                            drop_keys.begin() + std::min(batch_count + settings.max_drop_size_one_batch, drop_keys.size())});
 
-                        const size_t batch_count_end = batch_count + max_drop_size_one_batch;
+                        const size_t batch_count_end = batch_count + settings.max_drop_size_one_batch;
                         /// clear part cache immediately after drop from metastore
                         if (need_invalid_part_cache)
                         {
@@ -3554,7 +3560,7 @@ namespace Catalog
                                         commit_data.delete_bitmaps.begin() + right_bound - mark1});
                             }
                         }
-                        batch_count += max_drop_size_one_batch;
+                        batch_count += settings.max_drop_size_one_batch;
                     }
                 }
                 else
@@ -3588,13 +3594,13 @@ namespace Catalog
                 String uuid_str = UUIDHelpers::UUIDToString(storage_id.uuid);
 
                 /// write resources in batch, max batch size is max_commit_size_one_batch
-                auto begin = resources.begin(), end = std::min(resources.end(), begin + max_commit_size_one_batch);
+                auto begin = resources.begin(), end = std::min(resources.end(), begin + settings.max_commit_size_one_batch);
                 while (begin < end)
                 {
                     UndoResources tmp{begin, end};
-                    meta_proxy->writeUndoBuffer(name_space, txnID.toUInt64(), context.getHostWithPorts().getRPCAddress(), uuid_str, tmp);
+                    meta_proxy->writeUndoBuffer(name_space, txnID.toUInt64(), context.getHostWithPorts().getRPCAddress(), uuid_str, tmp, settings.write_undo_buffer_new_key);
                     begin = end;
-                    end = std::min(resources.end(), begin + max_commit_size_one_batch);
+                    end = std::min(resources.end(), begin + settings.max_commit_size_one_batch);
                 }
             },
             ProfileEvents::WriteUndoBufferConstResourceSuccess,
@@ -3609,13 +3615,13 @@ namespace Catalog
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Storage uuid of table {} can't be empty", storage_id.getNameForLogs());
                 String uuid_str = UUIDHelpers::UUIDToString(storage_id.uuid);
 
-                auto begin = resources.begin(), end = std::min(resources.end(), begin + max_commit_size_one_batch);
+                auto begin = resources.begin(), end = std::min(resources.end(), begin + settings.max_commit_size_one_batch);
                 while (begin < end)
                 {
                     UndoResources tmp{std::make_move_iterator(begin), std::make_move_iterator(end)};
-                    meta_proxy->writeUndoBuffer(name_space, txnID.toUInt64(), context.getHostWithPorts().getRPCAddress(), uuid_str, tmp);
+                    meta_proxy->writeUndoBuffer(name_space, txnID.toUInt64(), context.getHostWithPorts().getRPCAddress(), uuid_str, tmp, settings.write_undo_buffer_new_key);
                     begin = end;
-                    end = std::min(resources.end(), begin + max_commit_size_one_batch);
+                    end = std::min(resources.end(), begin + settings.max_commit_size_one_batch);
                 }
             },
             ProfileEvents::WriteUndoBufferNoConstResourceSuccess,
@@ -3639,13 +3645,18 @@ namespace Catalog
         std::unordered_map<String, UndoResources> res;
         runWithMetricSupport(
             [&] {
-                auto it = meta_proxy->getUndoBuffer(name_space, txnID.toUInt64());
-                while (it->next())
-                {
-                    UndoResource resource = UndoResource::deserialize(it->value());
-                    resource.txn_id = txnID;
-                    res[resource.uuid()].emplace_back(std::move(resource));
-                }
+                auto get_func = [&](bool write_undo_buffer_new_key) {
+                    auto it = meta_proxy->getUndoBuffer(name_space, txnID.toUInt64(), write_undo_buffer_new_key);
+                    while (it->next())
+                    {
+                        UndoResource resource = UndoResource::deserialize(it->value());
+                        resource.txn_id = txnID;
+                        res[resource.uuid()].emplace_back(std::move(resource));
+                    }
+                };
+                /// Get both old and new undo buffer keys;
+                get_func(true);
+                get_func(false);
             },
             ProfileEvents::GetUndoBufferSuccess,
             ProfileEvents::GetUndoBufferFailed);
@@ -4450,9 +4461,9 @@ namespace Catalog
                 String table_uuid = UUIDHelpers::UUIDToString(storage->getStorageUUID());
                 String key_prefix = MetastoreProxy::stagedDataPartPrefix(name_space, table_uuid);
 
-                for (size_t beg = 0; beg < parts.size(); beg += max_drop_size_one_batch)
+                for (size_t beg = 0; beg < parts.size(); beg += settings.max_drop_size_one_batch)
                 {
-                    size_t end = std::min(beg + max_drop_size_one_batch, parts.size());
+                    size_t end = std::min(beg + settings.max_drop_size_one_batch, parts.size());
 
                     Strings drop_keys;
                     for (auto it = parts.begin() + beg; it != parts.begin() + end; ++it)
@@ -6397,8 +6408,8 @@ namespace Catalog
             getPartitionIDs(to_tbl, nullptr),
             detached_bitmaps,
             bitmaps,
-            max_commit_size_one_batch,
-            max_drop_size_one_batch);
+            settings.max_commit_size_one_batch,
+            settings.max_drop_size_one_batch);
 
         if (context.getPartCacheManager())
         {
@@ -6507,8 +6518,8 @@ namespace Catalog
             commit_parts,
             attached_bitmaps,
             bitmaps,
-            max_commit_size_one_batch,
-            max_drop_size_one_batch);
+            settings.max_commit_size_one_batch,
+            settings.max_drop_size_one_batch);
 
         if (context.getPartCacheManager())
         {
@@ -6585,8 +6596,8 @@ namespace Catalog
             detached_visible_part_size,
             detached_staged_part_size,
             bitmap_names,
-            max_commit_size_one_batch,
-            max_drop_size_one_batch);
+            settings.max_commit_size_one_batch,
+            settings.max_drop_size_one_batch);
 
         Protos::DataModelPartVector attached_parts;
         for (const auto& [meta, version] : attached_metas)
@@ -6666,8 +6677,8 @@ namespace Catalog
             detached_part_metas,
             attached_bitmap_names,
             detached_bitmap_metas,
-            max_commit_size_one_batch,
-            max_drop_size_one_batch);
+            settings.max_commit_size_one_batch,
+            settings.max_drop_size_one_batch);
 
         if (context.getPartCacheManager())
         {

--- a/src/Catalog/Catalog.h
+++ b/src/Catalog/Catalog.h
@@ -265,12 +265,11 @@ public:
         const TxnTimestamp & ts,
         const Context * session_context,
         VisibilityLevel visibility = VisibilityLevel::Visible,
-        bool execute_filter = true,
         const std::set<Int64> & bucket_numbers = {});
 
     ServerDataPartsWithDBM getTrashedPartsInPartitionsWithDBM(const ConstStoragePtr & storage, const Strings & partitions, const TxnTimestamp & ts);
 
-    ServerDataPartsVector getTrashedPartsInPartitions(const ConstStoragePtr & storage, const Strings & partitions, const TxnTimestamp & ts, bool execute_filter = true);
+    ServerDataPartsVector getTrashedPartsInPartitions(const ConstStoragePtr & storage, const Strings & partitions, const TxnTimestamp & ts, VisibilityLevel visibility = VisibilityLevel::Visible);
 
     bool hasTrashedPartsInPartition(const ConstStoragePtr & storage, const String & partition);
 
@@ -283,7 +282,7 @@ public:
     DataPartsVector getStagedParts(const ConstStoragePtr & table, const TxnTimestamp & ts, const NameSet * partitions = nullptr);
 
     ServerDataPartsWithDBM getStagedServerDataPartsWithDBM(const ConstStoragePtr & table, const TxnTimestamp & ts, const NameSet * partitions = nullptr);
-    ServerDataPartsVector getStagedServerDataParts(const ConstStoragePtr & table, const TxnTimestamp & ts, const NameSet * partitions = nullptr, bool execute_filter = true);
+    ServerDataPartsVector getStagedServerDataParts(const ConstStoragePtr & table, const TxnTimestamp & ts, const NameSet * partitions = nullptr, VisibilityLevel visibility = VisibilityLevel::Visible);
 
     /////////////////////////////
     /// Delete bitmaps API (UNIQUE KEY)
@@ -295,11 +294,11 @@ public:
         const Strings & partitions,
         const TxnTimestamp & ts,
         const Context * session_context = nullptr,
-        bool execute_filter = true);
+        VisibilityLevel visibility = VisibilityLevel::Visible);
     DeleteBitmapMetaPtrVector getDeleteBitmapsInPartitionsFromMetastore(
-        const ConstStoragePtr & storage, const Strings & partitions, const TxnTimestamp & ts, bool execute_filter = true);
+        const ConstStoragePtr & storage, const Strings & partitions, const TxnTimestamp & ts, VisibilityLevel visibility = VisibilityLevel::Visible);
     DeleteBitmapMetaPtrVector getTrashedDeleteBitmapsInPartitions(
-        const ConstStoragePtr & storage, const Strings & partitions, const TxnTimestamp & ts, bool execute_filter = true);
+        const ConstStoragePtr & storage, const Strings & partitions, const TxnTimestamp & ts, VisibilityLevel visibility = VisibilityLevel::Visible);
 
     /// get bitmaps by keys
     DeleteBitmapMetaPtrVector getDeleteBitmapByKeys(const StoragePtr & storage, const NameSet & keys);
@@ -856,7 +855,7 @@ private:
     DataModelPartWithNameVector getDataPartsMetaFromMetastore(
         const ConstStoragePtr & storage, const Strings & required_partitions, const Strings & full_partitions, const TxnTimestamp & ts, bool from_trash = false);
     DeleteBitmapMetaPtrVector getDeleteBitmapsInPartitionsImpl(
-        const ConstStoragePtr & storage, const Strings & partitions, const TxnTimestamp & ts, bool from_trash = false, bool execute_filter = true);
+        const ConstStoragePtr & storage, const Strings & partitions, const TxnTimestamp & ts, bool from_trash = false, VisibilityLevel visibility = VisibilityLevel::Visible);
     DataModelDeleteBitmapPtrVector getDeleteBitmapsInPartitionsImpl(
         const ConstStoragePtr & storage, const Strings & required_partitions, const Strings & full_partitions, const TxnTimestamp & ts);
 

--- a/src/Catalog/Catalog.h
+++ b/src/Catalog/Catalog.h
@@ -19,6 +19,7 @@
 #include <optional>
 #include <set>
 #include <Catalog/CatalogUtils.h>
+#include <Catalog/CatalogSettings.h>
 #include <Catalog/DataModelPartWrapper.h>
 #include <Catalog/MetastoreProxy.h>
 #include <Core/SettingsEnums.h>
@@ -94,6 +95,8 @@ public:
     Catalog(Context & _context, const MetastoreConfig & config, String _name_space = "default");
 
     ~Catalog() = default;
+
+    void loadFromConfig(const String & config_elem, const Poco::Util::AbstractConfiguration & config);
 
     MetastoreProxy::MetastorePtr getMetastore();
 
@@ -840,10 +843,9 @@ private:
     const String name_space;
     String topology_key;
 
-    UInt32 max_commit_size_one_batch {2000};
     std::unordered_map<UUID, std::shared_ptr<std::mutex>> nhut_mutex;
     std::mutex all_storage_nhut_mutex;
-    UInt32 max_drop_size_one_batch {10000};
+    CatalogSettings settings;
 
     std::shared_ptr<Protos::DataModelDB> tryGetDatabaseFromMetastore(const String & database, const UInt64 & ts);
     std::shared_ptr<Protos::DataModelTable>

--- a/src/Catalog/CatalogSettings.cpp
+++ b/src/Catalog/CatalogSettings.cpp
@@ -1,0 +1,48 @@
+#include <Catalog/CatalogSettings.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int INVALID_CONFIG_PARAMETER;
+}
+
+template <typename T>
+void valueLoadFromConfig(const Poco::Util::AbstractConfiguration & config, const String & key, AtomicSetting<T> & value)
+{
+    if (config.has(key))
+        value = config.getUInt64(key);
+}
+
+template <>
+void valueLoadFromConfig<bool>(const Poco::Util::AbstractConfiguration & config, const String & key, AtomicSettingBool & value)
+{
+    if (config.has(key))
+        value = config.getBool(key);
+}
+
+void CatalogSettings::loadFromConfig(const String & config_elem, const Poco::Util::AbstractConfiguration & config)
+{
+    if (!config.has(config_elem))
+        return;
+
+    Poco::Util::AbstractConfiguration::Keys config_keys;
+    config.keys(config_elem, config_keys);
+
+    for (const String & key : config_keys)
+    {
+        auto full_key = config_elem + "." + key;
+
+#define SET(TYPE, NAME, DEFAULT) \
+        else if (key == #NAME) valueLoadFromConfig(config, full_key, this->NAME);
+
+        if (false) {}
+        APPLY_FOR_CATALOG_SETTINGS(SET)
+        else
+            throw Exception("Unknown Catalog setting " + key + " in config", ErrorCodes::INVALID_CONFIG_PARAMETER);
+#undef SET
+    }
+}
+}

--- a/src/Catalog/CatalogSettings.h
+++ b/src/Catalog/CatalogSettings.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <Poco/Util/AbstractConfiguration.h>
+#include <Core/Defines.h>
+#include <Core/Types.h>
+#include <atomic>
+
+namespace DB
+{
+
+template <typename T>
+struct AtomicSetting
+{
+    std::atomic<T> value;
+    AtomicSetting(T t) : value(t) {}
+    operator T() const { return get(); }
+    AtomicSetting & operator=(T t) { set(t); return *this; }
+    void set(T t) { value = t; }
+    T get() const { return value.load(std::memory_order_relaxed); }
+};
+
+using AtomicSettingUInt64 = AtomicSetting<UInt64>;
+using AtomicSettingBool = AtomicSetting<bool>;
+
+/** Settings for Catalog
+  */
+struct CatalogSettings
+{
+
+#define APPLY_FOR_CATALOG_SETTINGS(M) \
+    M(AtomicSettingUInt64, max_commit_size_one_batch, 500)                                                                 \
+    M(AtomicSettingUInt64, max_drop_size_one_batch, 1000)                                                               \
+    M(AtomicSettingBool, write_undo_buffer_new_key, false)                                               \
+
+#define DECLARE(TYPE, NAME, DEFAULT) \
+    TYPE NAME {DEFAULT};
+
+    APPLY_FOR_CATALOG_SETTINGS(DECLARE)
+#undef DECLARE
+
+public:
+    void loadFromConfig(const String & config_elem, const Poco::Util::AbstractConfiguration & config);
+};
+}

--- a/src/CloudServices/CnchServerServiceImpl.cpp
+++ b/src/CloudServices/CnchServerServiceImpl.cpp
@@ -587,8 +587,7 @@ void CnchServerServiceImpl::fetchDataParts(
                 partition_list,
                 TxnTimestamp{request->timestamp()},
                 nullptr,
-                /*visibility=*/Catalog::VisibilityLevel::All,
-                /*execute_filter=*/false);
+                /*visibility=*/Catalog::VisibilityLevel::All);
 
             /// Filter parts by bucket numbers if table is bucket table and cluster ready
             if (!parts.empty() && !request->bucket_numbers().empty() && storage->isBucketTable() && gc->getCnchCatalog()->isTableClustered(storage->getStorageUUID()))
@@ -651,7 +650,7 @@ void CnchServerServiceImpl::fetchDeleteBitmaps(
                 partition_list.emplace_back(partition);
 
             auto bitmaps = gc->getCnchCatalog()->getDeleteBitmapsInPartitions(
-                storage, partition_list, TxnTimestamp{request->timestamp()}, nullptr, /*execute_filter=*/false);
+                storage, partition_list, TxnTimestamp{request->timestamp()}, nullptr, Catalog::VisibilityLevel::All);
             auto & mutable_parts = *response->mutable_delete_bitmaps();
             for (const auto & bitmap : bitmaps)
                 *mutable_parts.Add() = *bitmap->getModel();

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -880,6 +880,8 @@
 \
     M(PartsToAttach, "") \
     M(NumOfRowsToAttach, "") \
+    M(VWQueueMilliseconds, "Total time spent to wait in virtual warehouse queue") \
+    M(VWQueueType, "Which type of virtual warehouse queue") \
     M(ScheduleTimeMilliseconds, "Total time spent to schedule plan segment") \
     \
     M(ScheduledDedupTaskNumber, "Total number of scheduled dedup task") \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -1434,6 +1434,9 @@ enum PreloadLevelSettings : UInt64
     M(Bool, enable_early_stop_metric, 0, "Whether output metrics of early stop", 0) \
     M(UInt64, query_queue_size, 100, "Max query queue size", 0) \
     M(Bool, enable_query_queue, false, "Whether enable query queue", 0) \
+    M(VWQueueMode, vw_queue_mode, VWQueueMode::Force, "Whether enqueue virtual warehouse queue: skip/match/force", 0) \
+    M(QueueName, queue_name, QueueName::Auto, "the name of vw queue: highest/high/normal/low/lowest/auto", 0) \
+    M(UInt64, vw_query_queue_timeout_ms, 100000, "Max queue pending time in ms", 0) \
     M(UInt64, query_queue_timeout_ms, 100000, "Max queue pending time in ms", 0) \
     M(Bool, enable_concurrency_control, false, "Whether enable concurrency control", 0) \
     M(UInt64, operator_profile_receive_timeout, 3000, "Max waiting time for operator profile in ms", 0) \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -1300,7 +1300,7 @@ enum PreloadLevelSettings : UInt64
     M(Milliseconds, topology_retry_interval_ms, 100, "Interval of topology background task to retry.", 0) \
     M(Milliseconds, topology_lease_life_ms, 12000, "Expiration time of topology lease.", 0) \
     M(Milliseconds, topology_session_restart_check_ms, 120, "Check and try to restart leader election for server master", 0) \
-    M(UInt64, catalog_max_commit_size, 2000, "Max record number to be committed in one batch.", 0) \
+    M(UInt64, catalog_max_commit_size, 500, "Max record number to be committed in one batch.", 0) \
     M(Bool, catalog_enable_multiple_threads, false, "Whether leverage multiple threads to handle metadata.", 0) \
     M(UInt64, catalog_multiple_threads_min_parts, 10000, "Minimum parts number to enable multi-thread in calc visible parts.", 0) \
     M(Bool, server_write_ha, false, "Whether to enable write on non-host server if host server is not available. Directly commit from non-host server.", 0) \

--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -172,6 +172,20 @@ IMPLEMENT_SETTING_ENUM(BackupVWMode, ErrorCodes::BAD_ARGUMENTS,
      {"round_robin", BackupVWMode::ROUND_ROBIN},
      {"backup_only", BackupVWMode::BACKUP_ONLY}})
 
+IMPLEMENT_SETTING_ENUM(QueueName, ErrorCodes::BAD_ARGUMENTS,
+    {{"highest", QueueName::Highest},
+     {"high", QueueName::High},
+     {"normal", QueueName::Normal},
+     {"low", QueueName::Low},
+     {"lowest", QueueName::Lowest},
+     {"count", QueueName::Count},
+     {"auto", QueueName::Auto}})
+
+IMPLEMENT_SETTING_ENUM(VWQueueMode, ErrorCodes::BAD_ARGUMENTS,
+    {{"skip", VWQueueMode::Skip},
+     {"match", VWQueueMode::Match},
+     {"force", VWQueueMode::Force}})
+
 IMPLEMENT_SETTING_ENUM(StatisticsCachePolicy, ErrorCodes::BAD_ARGUMENTS,
     {{"default", StatisticsCachePolicy::Default},
      {"cache", StatisticsCachePolicy::Cache},

--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -309,6 +309,28 @@ enum class BackupVWMode
 
 DECLARE_SETTING_ENUM(BackupVWMode)
 
+enum class QueueName : uint32_t
+{
+    Highest = 0,
+    High,
+    Normal,
+    Low,
+    Lowest,
+    Count,
+    Auto
+};
+
+DECLARE_SETTING_ENUM(QueueName);
+
+enum class VWQueueMode : uint32_t
+{
+    Skip = 0,
+    Match,
+    Force 
+};
+
+DECLARE_SETTING_ENUM(VWQueueMode);
+
 enum class SpanHierarchy : int
 {
     TRACE = 0,

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -89,6 +89,7 @@
 #include <Interpreters/PreparedStatement/PreparedStatementManager.h>
 #include <Interpreters/ProcessList.h>
 #include <Interpreters/QueueManager.h>
+#include <Interpreters/VirtualWarehouseQueue.h>
 #include <Interpreters/SegmentScheduler.h>
 #include <Interpreters/SynonymsExtensions.h>
 #include <Interpreters/SystemLog.h>

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -303,6 +303,9 @@ using WorkerGroupStatusPtr = std::shared_ptr<WorkerGroupStatus>;
 struct QeueueThrottlerDeleter;
 using QueueThrottlerDeleterPtr = std::shared_ptr<QeueueThrottlerDeleter>;
 
+struct DequeueRelease;
+using DequeueReleasePtr = std::shared_ptr<DequeueRelease>;
+
 class BindingCacheManager;
 using BindingCacheManagerPtr = std::shared_ptr<BindingCacheManager>;
 
@@ -602,6 +605,7 @@ private:
     mutable WorkerGroupHandle current_worker_group;
     mutable WorkerGroupHandle health_worker_group;
 
+    DequeueReleasePtr dequeue_ptr;
     /// Transaction for each query, query level
     TransactionCnchPtr current_cnch_txn;
 
@@ -1121,6 +1125,17 @@ public:
     {
         queue_throttler_ptr = ptr;
     }
+
+    void setDequeuePtr(DequeueReleasePtr ptr)
+    {
+        dequeue_ptr = ptr;
+    }
+
+    DequeueReleasePtr & getDequeuePtr()
+    {
+        return dequeue_ptr;
+    }
+
     ManipulationList & getManipulationList();
     const ManipulationList & getManipulationList() const;
 

--- a/src/Interpreters/IInterpreter.h
+++ b/src/Interpreters/IInterpreter.h
@@ -25,13 +25,9 @@ public:
 
     // Fill query log element with query kind, query databases, query tables and query columns.
     void extendQueryLogElem(
-        QueryLogElement & elem,
-        const ASTPtr & ast,
-        ContextPtr context,
-        const String & query_database,
-        const String & query_table) const;
+        QueryLogElement & elem, const ASTPtr & ast, ContextPtr context, const String & query_database, const String & query_table) const;
 
-    virtual void extendQueryLogElemImpl(QueryLogElement &, const ASTPtr &, ContextPtr) const {}
+    virtual void extendQueryLogElemImpl(QueryLogElement &, const ASTPtr &, ContextPtr) const { }
 
     virtual ~IInterpreter() = default;
 };

--- a/src/Interpreters/InterpreterAlterWarehouseQuery.cpp
+++ b/src/Interpreters/InterpreterAlterWarehouseQuery.cpp
@@ -14,18 +14,31 @@
  */
 
 
+#include <optional>
 #include <Interpreters/Context.h>
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/InterpreterAlterWarehouseQuery.h>
+#include <Interpreters/VirtualWarehouseQueue.h>
 #include <Parsers/ASTAlterWarehouseQuery.h>
+#include <Parsers/ASTAssignment.h>
+#include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSetQuery.h>
+#include <Parsers/CommonParsers.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Protos/resource_manager_rpc.pb.h>
 #include <ResourceManagement/CommonData.h>
 #include <ResourceManagement/ResourceManagerClient.h>
 #include <ResourceManagement/VirtualWarehouseType.h>
+#include <Storages/System/CollectWhereClausePredicate.h>
+#include <Poco/Logger.h>
+#include "Common/Exception.h"
+#include <common/logger_useful.h>
+#include "Core/SettingsEnums.h"
+#include "Core/SettingsFields.h"
+#include "Parsers/ASTFunction.h"
 
 namespace DB
 {
-
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
@@ -37,8 +50,20 @@ namespace ErrorCodes
 }
 
 InterpreterAlterWarehouseQuery::InterpreterAlterWarehouseQuery(const ASTPtr & query_ptr_, ContextPtr context_)
-    : WithContext(context_), query_ptr(query_ptr_) {}
+    : WithContext(context_), query_ptr(query_ptr_)
+{
+}
 
+void checkQueueName(const String & queue_name_)
+{
+    SettingFieldEnum<QueueName, SettingFieldQueueNameTraits> current_name;
+    current_name.parseFromString(queue_name_);
+    
+    if (current_name.value >= QueueName::Count)
+    {
+        throw Exception("Unknown queue_name : " + queue_name_, ErrorCodes::SYNTAX_ERROR);
+    }
+}
 
 BlockIO InterpreterAlterWarehouseQuery::execute()
 {
@@ -50,116 +75,332 @@ BlockIO InterpreterAlterWarehouseQuery::execute()
 
     ResourceManagement::VirtualWarehouseAlterSettings vw_alter_settings;
 
-    if (alter.settings)
+    // update queue info
+    // alter warehouse vw_name add rule set tables = ['xxx', 'yyy'], rule_name = 'rule_xx' where queue_name = 'yyy';
+    if (alter.type == ASTAlterWarehouseQuery::Type::ADD_RULE)
     {
-        for (const auto & change : alter.settings->changes)
+        bool has_rule_name = false;
+        bool has_queue_name = false;
+        vw_alter_settings.queue_data = std::make_optional<DB::ResourceManagement::QueueData>();
+        vw_alter_settings.queue_data->queue_rules.resize(1);
+        auto & first_rule = vw_alter_settings.queue_data->queue_rules[0];
+        vw_alter_settings.queue_alter_type = Protos::QueueAlterType::ADD_RULE;
+        for (const auto & child : alter.assignment_list->children)
         {
-            if (change.name == "type")
+            if (const ASTAssignment * assignment = child->as<ASTAssignment>())
             {
-                using RMType = ResourceManagement::VirtualWarehouseType;
-                auto value = change.value.safeGet<std::string>();
-                auto type = RMType(ResourceManagement::toVirtualWarehouseType(&value[0]));
-                if (type == RMType::Unknown)
-                    throw Exception("Unknown Virtual Warehouse type: " + value, ErrorCodes::RESOURCE_MANAGER_UNKNOWN_SETTING);
-                vw_alter_settings.type = type;
-            }
-            else if (change.name == "auto_suspend")
-            {
-                vw_alter_settings.auto_suspend = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "auto_resume")
-            {
-                vw_alter_settings.auto_resume = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "num_workers")
-            {
-                vw_alter_settings.num_workers = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "min_worker_groups")
-            {
-                vw_alter_settings.min_worker_groups = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "max_worker_groups")
-            {
-                vw_alter_settings.max_worker_groups = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "max_concurrent_queries")
-            {
-                vw_alter_settings.max_concurrent_queries = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "max_queued_queries")
-            {
-                vw_alter_settings.max_queued_queries = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "max_queued_waiting_ms")
-            {
-                vw_alter_settings.max_queued_waiting_ms = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "vw_schedule_algo")
-            {
-                auto value = change.value.safeGet<std::string>();
-                auto algo = ResourceManagement::toVWScheduleAlgo(&value[0]);
-                if (algo == ResourceManagement::VWScheduleAlgo::Unknown)
-                    throw Exception("Wrong vw_schedule_algo: " + value, ErrorCodes::RESOURCE_MANAGER_WRONG_VW_SCHEDULE_ALGO);
-                vw_alter_settings.vw_schedule_algo = algo;
-            }
-            else if (change.name == "max_auto_borrow_links")
-            {
-                vw_alter_settings.max_auto_borrow_links = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "max_auto_lend_links")
-            {
-                vw_alter_settings.max_auto_lend_links = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "cpu_busy_threshold")
-            {
-                vw_alter_settings.cpu_busy_threshold = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "mem_busy_threshold")
-            {
-                vw_alter_settings.mem_busy_threshold = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "cpu_idle_threshold")
-            {
-                vw_alter_settings.cpu_idle_threshold = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "mem_idle_threshold")
-            {
-                vw_alter_settings.mem_idle_threshold = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "cpu_threshold_for_recall")
-            {
-                vw_alter_settings.cpu_threshold_for_recall = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "mem_threshold_for_recall")
-            {
-                vw_alter_settings.mem_threshold_for_recall = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "cooldown_seconds_after_scaleup")
-            {
-                vw_alter_settings.cooldown_seconds_after_scaleup = change.value.safeGet<size_t>();
-            }
-            else if (change.name == "cooldown_seconds_after_scaledown")
-            {
-                vw_alter_settings.cooldown_seconds_after_scaledown = change.value.safeGet<size_t>();
+                const auto & assign_name = assignment->column_name;
+                LOG_TRACE(&Poco::Logger::get("InterpreterAlterWarehouseQuery"), "assign name {}", assign_name);
+                if (const ASTLiteral * literal = assignment->expression()->as<ASTLiteral>())
+                {
+                    if (assign_name == "rule_name")
+                    {
+                        has_rule_name = true;
+                        first_rule.rule_name = literal->value.safeGet<String>();
+                    }
+                    else if (assign_name == "tables" && (literal->value.getType() == Field::Types::Array))
+                    {
+                        for (const auto & table : literal->value.safeGet<Array>())
+                        {
+                            first_rule.tables.push_back(table.safeGet<String>());
+                        }
+                    }
+                    else if (assign_name == "databases" && (literal->value.getType() == Field::Types::Array))
+                    {
+                        for (const auto & database : literal->value.safeGet<Array>())
+                        {
+                            first_rule.databases.push_back(database.safeGet<String>());
+                        }
+                    }
+                    else if (assign_name == "ip")
+                    {
+                        first_rule.ip = literal->value.safeGet<String>();
+                    }
+                    else if (assign_name == "user")
+                    {
+                        first_rule.user = literal->value.safeGet<String>();
+                    }
+                    else if (assign_name == "query_id")
+                    {
+                        first_rule.query_id = literal->value.safeGet<String>();
+                    }
+                    else if (assign_name == "fingerprint")
+                    {
+                        first_rule.fingerprint = literal->value.safeGet<String>();
+                    }
+                    else
+                        throw Exception("Syntax error in alter warehouse statement. " + child->getID(), ErrorCodes::SYNTAX_ERROR);
+                }
+                else
+                    throw Exception("Syntax error in alter warehouse statement. " + child->getID(), ErrorCodes::SYNTAX_ERROR);
             }
             else
+                throw Exception("Syntax error in alter warehouse statement. " + child->getID(), ErrorCodes::SYNTAX_ERROR);
+        }
+
+        std::map<String, String> column_to_value;
+        collectWhereClausePredicate(alter.predicate, column_to_value);
+        if (column_to_value.find("queue_name") != column_to_value.end())
+        {
+            has_queue_name = true;
+            checkQueueName(column_to_value["queue_name"]);
+            vw_alter_settings.queue_data->queue_name = column_to_value["queue_name"];
+        }
+
+        if (!has_rule_name || !has_queue_name)
+            throw Exception("Syntax error : Not contain `rule_name` or `queue_name`", ErrorCodes::SYNTAX_ERROR);
+
+        if (auto client = getContext()->getResourceManagerClient())
+        {
+            client->updateVirtualWarehouse(vw_name, vw_alter_settings);
+        }
+        else
+            throw Exception("Can't apply DDL of warehouse as RM is not enabled.", ErrorCodes::RESOURCE_MANAGER_ILLEGAL_CONFIG);
+    }
+    // alter warehouse vw_name delete rule where rule_name = 'rule_xx' and queue_name = 'yyy';
+    else if (alter.type == ASTAlterWarehouseQuery::Type::DELETE_RULE)
+    {
+        bool has_rule_name = false;
+        bool has_queue_name = false;
+        vw_alter_settings.queue_alter_type = Protos::QueueAlterType::DELETE_RULE;
+        std::map<String, String> column_to_value;
+        collectWhereClausePredicate(alter.predicate, column_to_value);
+        if (column_to_value.find("queue_name") != column_to_value.end())
+        {
+            has_queue_name = true;
+            checkQueueName(column_to_value["queue_name"]);
+            vw_alter_settings.queue_name = column_to_value["queue_name"];
+        }
+        if (column_to_value.find("rule_name") != column_to_value.end())
+        {
+            has_rule_name = true;
+            vw_alter_settings.rule_name = column_to_value["rule_name"];
+        }
+        if (!has_rule_name || !has_queue_name)
+            throw Exception("Syntax error : Not contain `rule_name` or `queue_name`", ErrorCodes::SYNTAX_ERROR);
+
+        if (auto client = getContext()->getResourceManagerClient())
+        {
+            client->updateVirtualWarehouse(vw_name, vw_alter_settings);
+        }
+        else
+            throw Exception("Can't apply DDL of warehouse as RM is not enabled.", ErrorCodes::RESOURCE_MANAGER_ILLEGAL_CONFIG);
+    }
+    // alter warehouse vw_name modify rule set max_concurrency = 3 where queue_name = 'yyy';
+    else if (alter.type == ASTAlterWarehouseQuery::Type::MODIFY_RULE)
+    {
+        vw_alter_settings.queue_alter_type = Protos::QueueAlterType::MODIFY_RULE;
+
+        for (const auto & child : alter.assignment_list->children)
+        {
+            if (const ASTAssignment * assignment = child->as<ASTAssignment>())
             {
-                throw Exception("Unknown setting " + change.name, ErrorCodes::RESOURCE_MANAGER_UNKNOWN_SETTING);
+                const auto & assign_name = assignment->column_name;
+                LOG_TRACE(
+                    &Poco::Logger::get("InterpreterAlterWarehouseQuery"),
+                    "assign name {}, assygn type {}",
+                    assign_name,
+                    int(assignment->expression()->getType()));
+                if (const ASTLiteral * literal = assignment->expression()->as<ASTLiteral>())
+                {
+                    if (assign_name == "max_concurrency")
+                    {
+                        vw_alter_settings.max_concurrency = literal->value.safeGet<size_t>();
+                    }
+                    else if (assign_name == "query_queue_size")
+                    {
+                        vw_alter_settings.query_queue_size = literal->value.safeGet<size_t>();
+                    }
+                    else if (assign_name == "query_id")
+                    {
+                        vw_alter_settings.query_id = literal->value.safeGet<String>();
+                    }
+                    else if (assign_name == "user")
+                    {
+                        vw_alter_settings.user = literal->value.safeGet<String>();
+                    }
+                    else if (assign_name == "ip")
+                    {
+                        vw_alter_settings.ip = literal->value.safeGet<String>();
+                    }
+                    else if (assign_name == "tables")
+                    {
+                        vw_alter_settings.has_table = true;
+                        auto tables = literal->value.safeGet<Array>();
+                        for (const auto & table : tables)
+                        {
+                            vw_alter_settings.tables.push_back(table.safeGet<String>());
+                        }
+                    }
+                    else if (assign_name == "databases")
+                    {
+                        vw_alter_settings.has_database = true;
+                        auto dbs = literal->value.safeGet<Array>();
+                        for (const auto & db : dbs)
+                        {
+                            vw_alter_settings.databases.push_back(db.safeGet<String>());
+                        }
+                    }
+                    else if (assign_name == "fingerprint")
+                    {
+                        vw_alter_settings.fingerprint = literal->value.safeGet<String>();
+                    }
+                    else
+                        throw Exception("Unknown assign name " + assign_name, ErrorCodes::SYNTAX_ERROR);
+                }
+                else if (const ASTFunction * func = assignment->expression()->as<ASTFunction>())
+                {
+                    // In sql : alter warehouse  vw1 MODIFY RULE set tables = []  where queue_name = 'q1' and rule_name = 'r1';
+                    // The type of [] is array function.
+                    if (func->name == "array")
+                    {
+                        if (assign_name == "tables")
+                            vw_alter_settings.has_table = true;
+                        else if (assign_name == "databases")
+                            vw_alter_settings.has_database = true;
+                    }
+                }
+                else
+                {
+                    throw Exception("Unknown type", ErrorCodes::SYNTAX_ERROR);
+                }
             }
         }
+        std::map<String, String> column_to_value;
+        collectWhereClausePredicate(alter.predicate, column_to_value);
+        if (column_to_value.find("queue_name") != column_to_value.end())
+        {
+            checkQueueName(column_to_value["queue_name"]);
+            vw_alter_settings.queue_name = column_to_value["queue_name"];
+        }
+        else
+        {
+            throw Exception("Syntax error : Not contains `queue_name`", ErrorCodes::SYNTAX_ERROR);
+        }
+        if (column_to_value.find("rule_name") != column_to_value.end())
+        {
+            vw_alter_settings.rule_name = column_to_value["rule_name"];
+        }
+        if (auto client = getContext()->getResourceManagerClient())
+        {
+            client->updateVirtualWarehouse(vw_name, vw_alter_settings);
+        }
+        else
+            throw Exception("Can't apply DDL of warehouse as RM is not enabled.", ErrorCodes::RESOURCE_MANAGER_ILLEGAL_CONFIG);
     }
-
-    if (vw_alter_settings.min_worker_groups && vw_alter_settings.max_worker_groups
-        && vw_alter_settings.min_worker_groups > vw_alter_settings.max_worker_groups)
-        throw Exception("min_worker_groups should be less than or equal to max_worker_groups", ErrorCodes::RESOURCE_MANAGER_INCOMPATIBLE_SETTINGS);
-
-    if (auto client = getContext()->getResourceManagerClient())
-        client->updateVirtualWarehouse(vw_name, vw_alter_settings);
     else
-        throw Exception("Can't apply DDL of warehouse as RM is not enabled.", ErrorCodes::RESOURCE_MANAGER_ILLEGAL_CONFIG);
+    {
+        if (alter.settings)
+        {
+            for (const auto & change : alter.settings->changes)
+            {
+                if (change.name == "type")
+                {
+                    using RMType = ResourceManagement::VirtualWarehouseType;
+                    auto value = change.value.safeGet<std::string>();
+                    auto type = RMType(ResourceManagement::toVirtualWarehouseType(&value[0]));
+                    if (type == RMType::Unknown)
+                        throw Exception("Unknown Virtual Warehouse type: " + value, ErrorCodes::RESOURCE_MANAGER_UNKNOWN_SETTING);
+                    vw_alter_settings.type = type;
+                }
+                else if (change.name == "auto_suspend")
+                {
+                    vw_alter_settings.auto_suspend = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "auto_resume")
+                {
+                    vw_alter_settings.auto_resume = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "num_workers")
+                {
+                    vw_alter_settings.num_workers = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "min_worker_groups")
+                {
+                    vw_alter_settings.min_worker_groups = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "max_worker_groups")
+                {
+                    vw_alter_settings.max_worker_groups = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "max_concurrent_queries")
+                {
+                    vw_alter_settings.max_concurrent_queries = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "max_queued_queries")
+                {
+                    vw_alter_settings.max_queued_queries = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "max_queued_waiting_ms")
+                {
+                    vw_alter_settings.max_queued_waiting_ms = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "vw_schedule_algo")
+                {
+                    auto value = change.value.safeGet<std::string>();
+                    auto algo = ResourceManagement::toVWScheduleAlgo(&value[0]);
+                    if (algo == ResourceManagement::VWScheduleAlgo::Unknown)
+                        throw Exception("Wrong vw_schedule_algo: " + value, ErrorCodes::RESOURCE_MANAGER_WRONG_VW_SCHEDULE_ALGO);
+                    vw_alter_settings.vw_schedule_algo = algo;
+                }
+                else if (change.name == "max_auto_borrow_links")
+                {
+                    vw_alter_settings.max_auto_borrow_links = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "max_auto_lend_links")
+                {
+                    vw_alter_settings.max_auto_lend_links = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "cpu_busy_threshold")
+                {
+                    vw_alter_settings.cpu_busy_threshold = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "mem_busy_threshold")
+                {
+                    vw_alter_settings.mem_busy_threshold = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "cpu_idle_threshold")
+                {
+                    vw_alter_settings.cpu_idle_threshold = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "mem_idle_threshold")
+                {
+                    vw_alter_settings.mem_idle_threshold = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "cpu_threshold_for_recall")
+                {
+                    vw_alter_settings.cpu_threshold_for_recall = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "mem_threshold_for_recall")
+                {
+                    vw_alter_settings.mem_threshold_for_recall = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "cooldown_seconds_after_scaleup")
+                {
+                    vw_alter_settings.cooldown_seconds_after_scaleup = change.value.safeGet<size_t>();
+                }
+                else if (change.name == "cooldown_seconds_after_scaledown")
+                {
+                    vw_alter_settings.cooldown_seconds_after_scaledown = change.value.safeGet<size_t>();
+                }
+                else
+                {
+                    throw Exception("Unknown setting " + change.name, ErrorCodes::RESOURCE_MANAGER_UNKNOWN_SETTING);
+                }
+            }
+        }
+
+        if (vw_alter_settings.min_worker_groups && vw_alter_settings.max_worker_groups
+            && vw_alter_settings.min_worker_groups > vw_alter_settings.max_worker_groups)
+            throw Exception(
+                "min_worker_groups should be less than or equal to max_worker_groups", ErrorCodes::RESOURCE_MANAGER_INCOMPATIBLE_SETTINGS);
+
+        if (auto client = getContext()->getResourceManagerClient())
+            client->updateVirtualWarehouse(vw_name, vw_alter_settings);
+        else
+            throw Exception("Can't apply DDL of warehouse as RM is not enabled.", ErrorCodes::RESOURCE_MANAGER_ILLEGAL_CONFIG);
+    }
 
     return {};
 }
-
 }

--- a/src/Interpreters/InterpreterSelectQueryUseOptimizer.cpp
+++ b/src/Interpreters/InterpreterSelectQueryUseOptimizer.cpp
@@ -548,13 +548,13 @@ BlockIO InterpreterSelectQueryUseOptimizer::execute()
         //     return executeDDLQueryOnCluster(query_ptr, context);
         return executeCreatePreparedStatementQuery();
     }
-
     if (!plan_segment_tree_ptr)
     {
         std::pair<PlanSegmentTreePtr, std::set<StorageID>> plan_segment_tree_and_used_storage_ids = getPlanSegment();
         plan_segment_tree_ptr = std::move(plan_segment_tree_and_used_storage_ids.first);
     }
     size_t plan_segment_num = plan_segment_tree_ptr->getNodes().size();
+
     UInt64 max_plan_segment_num = context->getSettingsRef().max_plan_segment_num;
     if (max_plan_segment_num != 0 && plan_segment_num > max_plan_segment_num)
         throw Exception(

--- a/src/Interpreters/VirtualWarehouseHandle.cpp
+++ b/src/Interpreters/VirtualWarehouseHandle.cpp
@@ -14,13 +14,13 @@
  */
 
 #include <Catalog/Catalog.h>
-#include <Common/Exception.h>
-#include <Common/thread_local_rng.h>
 #include <Interpreters/VirtualWarehouseHandle.h>
 #include <Interpreters/WorkerGroupHandle.h>
+#include <Interpreters/WorkerStatusManager.h>
 #include <ResourceManagement/ResourceManagerClient.h>
 #include <ServiceDiscovery/IServiceDiscovery.h>
-#include <Interpreters/WorkerStatusManager.h>
+#include <Common/Exception.h>
+#include <Common/thread_local_rng.h>
 
 namespace DB
 {
@@ -34,7 +34,11 @@ namespace ErrorCodes
 }
 
 VirtualWarehouseHandleImpl::VirtualWarehouseHandleImpl(
-    VirtualWarehouseHandleSource source_, std::string name_, UUID uuid_, const ContextPtr global_context_, const VirtualWarehouseSettings & settings_)
+    VirtualWarehouseHandleSource source_,
+    std::string name_,
+    UUID uuid_,
+    const ContextPtr global_context_,
+    const VirtualWarehouseSettings & settings_)
     : WithContext(global_context_)
     , source(source_)
     , name(std::move(name_))
@@ -49,6 +53,8 @@ VirtualWarehouseHandleImpl::VirtualWarehouseHandleImpl(
     VirtualWarehouseHandleSource source_, const VirtualWarehouseData & vw_data, const ContextPtr global_context_)
     : VirtualWarehouseHandleImpl(source_, vw_data.name, vw_data.uuid, global_context_, vw_data.settings)
 {
+    LOG_DEBUG(log, "create virtual warehouse {}", name);
+    queue_manager.updateQueue(vw_data.settings.queue_datas);
 }
 
 bool VirtualWarehouseHandleImpl::empty(UpdateMode update_mode)
@@ -90,7 +96,7 @@ WorkerGroupHandle VirtualWarehouseHandleImpl::getWorkerGroup(const String & work
     return it->second;
 }
 
-void VirtualWarehouseHandleImpl::updateWorkerStatusFromRM(const std::vector<WorkerGroupData>& groups_data)
+void VirtualWarehouseHandleImpl::updateWorkerStatusFromRM(const std::vector<WorkerGroupData> & groups_data)
 {
     auto worker_status_manager = getContext()->getWorkerStatusManager();
     auto cannot_update_workers = worker_status_manager->getWorkersCannotUpdateFromRM();
@@ -116,7 +122,8 @@ void VirtualWarehouseHandleImpl::updateWorkerStatusFromRM(const std::vector<Work
     }
 }
 
-WorkerGroupHandle VirtualWarehouseHandleImpl::pickWorkerGroup([[maybe_unused]] VWScheduleAlgo algo, [[maybe_unused]] const Requirement & requirement, [[maybe_unused]] UpdateMode update_mode)
+WorkerGroupHandle VirtualWarehouseHandleImpl::pickWorkerGroup(
+    [[maybe_unused]] VWScheduleAlgo algo, [[maybe_unused]] const Requirement & requirement, [[maybe_unused]] UpdateMode update_mode)
 {
     return randomWorkerGroup();
 }
@@ -183,12 +190,16 @@ bool VirtualWarehouseHandleImpl::updateWorkerGroupsFromRM()
         }
 
         std::vector<WorkerGroupData> groups_data;
-        rm_client->getWorkerGroups(name, groups_data);
+        std::optional<VirtualWarehouseSettings> new_settings;
+        rm_client->getWorkerGroups(name, groups_data, new_settings, last_settings_timestamp);
         if (groups_data.empty())
         {
             LOG_DEBUG(log, "No worker group found in VW {} from RM", name);
             return false;
         }
+
+        if (new_settings)
+            updateSettings(*new_settings);
         updateWorkerStatusFromRM(groups_data);
         std::lock_guard lock(state_mutex);
 
@@ -229,7 +240,13 @@ bool VirtualWarehouseHandleImpl::updateWorkerGroupsFromRM()
     }
 }
 
-void VirtualWarehouseHandleImpl::updateWorkerStatusFromPSM(const IServiceDiscovery::WorkerGroupMap & groups_data, const std::string & vw_name)
+void VirtualWarehouseHandleImpl::updateSettings(const VirtualWarehouseSettings & new_settings)
+{
+    getQueueManager().updateQueue(new_settings.queue_datas);
+}
+
+void VirtualWarehouseHandleImpl::updateWorkerStatusFromPSM(
+    const IServiceDiscovery::WorkerGroupMap & groups_data, const std::string & vw_name)
 {
     auto worker_status_manager = getContext()->getWorkerStatusManager();
     auto cannot_update_workers = worker_status_manager->getWorkersCannotUpdateFromRM();
@@ -310,7 +327,8 @@ void VirtualWarehouseHandleImpl::filterGroup(const Requirement & requirement, st
 }
 
 /// pickLocally stage 2: select one group by algo.
-WorkerGroupHandle VirtualWarehouseHandleImpl::selectGroup([[maybe_unused]] const VWScheduleAlgo & algo, [[maybe_unused]] std::vector<WorkerGroupAndMetrics> & available_groups)
+WorkerGroupHandle VirtualWarehouseHandleImpl::selectGroup(
+    [[maybe_unused]] const VWScheduleAlgo & algo, [[maybe_unused]] std::vector<WorkerGroupAndMetrics> & available_groups)
 {
     return available_groups[0].first;
 
@@ -361,19 +379,20 @@ WorkerGroupHandle VirtualWarehouseHandleImpl::selectGroup([[maybe_unused]] const
 /// Picking a worker group from local cache. Two stages:
 /// - 1. filter worker groups by requirement.
 /// - 2. select one group by algo.
-WorkerGroupHandle VirtualWarehouseHandleImpl::pickLocally([[maybe_unused]] const VWScheduleAlgo & algo, [[maybe_unused]] const Requirement & requirement)
+WorkerGroupHandle
+VirtualWarehouseHandleImpl::pickLocally([[maybe_unused]] const VWScheduleAlgo & algo, [[maybe_unused]] const Requirement & requirement)
 {
     return randomWorkerGroup();
     /// TODO: (zuochuang.zema) refactor after multi worker groups is enabled.
 
-//     std::vector<WorkerGroupAndMetrics> available_groups;
-//     filterGroup(requirement, available_groups);
-//     if (available_groups.empty())
-//     {
-//         LOG_WARNING(log, "No available worker groups for requirement: {}, choose one randomly.", requirement.toDebugString());
-//         return randomWorkerGroup();
-//     }
-//     return selectGroup(algo, available_groups);
+    //     std::vector<WorkerGroupAndMetrics> available_groups;
+    //     filterGroup(requirement, available_groups);
+    //     if (available_groups.empty())
+    //     {
+    //         LOG_WARNING(log, "No available worker groups for requirement: {}, choose one randomly.", requirement.toDebugString());
+    //         return randomWorkerGroup();
+    //     }
+    //     return selectGroup(algo, available_groups);
 }
 
 /// Get a worker from the VW using a random strategy.
@@ -460,10 +479,10 @@ CnchWorkerClientPtr VirtualWarehouseHandleImpl::pickWorker(const String & worker
         return getWorkerGroup(worker_group_id)->getWorkerClient(skip_busy_worker);
 
     return randomWorkerGroup()->getWorkerClient(skip_busy_worker);
-
 }
 
-std::pair<UInt64, CnchWorkerClientPtr> VirtualWarehouseHandleImpl::pickWorker(const String & worker_group_id, UInt64 sequence, bool skip_busy_worker)
+std::pair<UInt64, CnchWorkerClientPtr>
+VirtualWarehouseHandleImpl::pickWorker(const String & worker_group_id, UInt64 sequence, bool skip_busy_worker)
 {
     if (!worker_group_id.empty())
         return getWorkerGroup(worker_group_id)->getWorkerClient(sequence, skip_busy_worker);

--- a/src/Interpreters/VirtualWarehouseHandle.h
+++ b/src/Interpreters/VirtualWarehouseHandle.h
@@ -18,6 +18,7 @@
 #include <Common/Exception.h>
 #include <CloudServices/CnchWorkerClient.h>
 #include <Interpreters/Context_fwd.h>
+#include <Interpreters/VirtualWarehouseQueue.h>
 #include <ResourceManagement/CommonData.h>
 #include <ResourceManagement/VWScheduleAlgo.h>
 #include <ServiceDiscovery/IServiceDiscovery.h>
@@ -118,12 +119,18 @@ public:
     /// So VW handle just forward the request to the target WG handle, or forward to a random WG if it's not specified.
     CnchWorkerClientPtr pickWorker(const String & worker_group_id, bool skip_busy_worker = true);
 
+    void updateSettings(const VirtualWarehouseSettings & settings);
     std::pair<UInt64, CnchWorkerClientPtr> pickWorker(const String & worker_group_id, UInt64 sequence, bool skip_busy_worker = true);
     CnchWorkerClientPtr getWorker();
     CnchWorkerClientPtr getWorkerByHash(const String & key);
     CnchWorkerClientPtr getWorkerByHostWithPorts(const HostWithPorts & host_ports);
     std::vector<CnchWorkerClientPtr> getAllWorkers();
 
+    VWQueueResultStatus enqueue(VWQueueInfoPtr queue_info, UInt64 timeout_ms)
+    {
+        return queue_manager.enqueue(queue_info, timeout_ms);
+    }
+    VirtualWarehouseQueueManager & getQueueManager() { return queue_manager; }
 private:
     bool addWorkerGroupImpl(const WorkerGroupHandle & worker_group, const std::lock_guard<std::mutex> & lock);
 
@@ -151,10 +158,12 @@ private:
     size_t force_update_interval_ns = 5ULL * 60 * 1000 * 1000 * 1000;
     size_t try_update_interval_ns = 500ULL * 1000 * 1000;
     std::atomic<UInt64> last_update_time_ns{0};
+    std::atomic<UInt64> last_settings_timestamp{0};
 
     mutable std::mutex state_mutex;
     Container worker_groups;
     std::atomic<size_t> pick_group_sequence = 0; /// round-robin index for pickWorkerGroup.
+    VirtualWarehouseQueueManager queue_manager;
 };
 
 using VirtualWarehouseHandle = std::shared_ptr<VirtualWarehouseHandleImpl>;

--- a/src/Interpreters/VirtualWarehouseQueue.cpp
+++ b/src/Interpreters/VirtualWarehouseQueue.cpp
@@ -1,0 +1,453 @@
+#include <sstream>
+#include <type_traits>
+#include <Interpreters/Context.h>
+#include <Interpreters/DatabaseAndTableWithAlias.h>
+#include <Interpreters/VirtualWarehouseHandle.h>
+#include <Interpreters/VirtualWarehouseQueue.h>
+#include <Parsers/ASTDeleteQuery.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTInsertQuery.h>
+#include <Parsers/ASTRefreshQuery.h>
+#include <Parsers/ASTTablesInSelectQuery.h>
+#include <Parsers/ASTUpdateQuery.h>
+#include <Parsers/SQLFingerprint.h>
+#include <Storages/StorageMaterializedView.h>
+#include "common/logger_useful.h"
+#include "Core/SettingsEnums.h"
+#include "Core/SettingsFields.h"
+#include "Parsers/IAST.h"
+#include "Parsers/IAST_fwd.h"
+
+namespace ProfileEvents
+{
+extern const Event VWQueueMilliseconds;
+extern const Event VWQueueType;
+}
+
+namespace DB
+{
+template <class T>
+bool matchContainer(T && query_info, T && rule_info, size_t & match_count)
+{
+    for (auto && ele : rule_info)
+    {
+        if (std::find(query_info.begin(), query_info.end(), ele) == query_info.end())
+            return false;
+    }
+    if (!rule_info.empty())
+        match_count++;
+    return true;
+}
+
+bool matchString(const std::string & query_info, const std::string & rule_info, size_t & match_count)
+{
+    if (!rule_info.empty())
+    {
+        auto ret = query_info == rule_info;
+        if (ret)
+            match_count++;
+        return ret;
+    }
+    return true;
+}
+bool matchRegex(const std::string & query_info, const RE2 * re, size_t & match_count)
+{
+    auto ret = RE2::FullMatch(query_info, *re);
+    if (ret)
+        match_count++;
+    return ret;
+}
+
+namespace ErrorCodes
+{
+    extern const int CNCH_QUEUE_QUERY_FAILURE;
+}
+
+void tryGetStorageFromAST(const ASTPtr & ast, ContextMutablePtr & context, StorageInfos & storage_infos)
+{
+    auto & database_catalog = DatabaseCatalog::instance();
+    if (auto * delete_query = ast->as<ASTDeleteQuery>())
+    {
+        auto database = delete_query->database.empty() ? context->getCurrentDatabase() : delete_query->database;
+        storage_infos.databases.push_back(database);
+        storage_infos.tables.push_back(database + "." + delete_query->table);
+    }
+    else if (auto * update = ast->as<ASTUpdateQuery>())
+    {
+        auto database = update->database.empty() ? context->getCurrentDatabase() : update->database;
+        storage_infos.databases.push_back(database);
+        storage_infos.tables.push_back(database + "." + update->table);
+    }
+    else if (auto * insert = ast->as<ASTInsertQuery>())
+    {
+        //this means the query is function insert, for example `insert into function CnchS3(...)
+        if (!insert->table_id.empty())
+        {
+            auto table_id = insert->table_id;
+            if (table_id.database_name.empty())
+                table_id.database_name = context->getCurrentDatabase();
+
+            storage_infos.databases.push_back(table_id.database_name);
+            storage_infos.tables.push_back(table_id.database_name + "." + table_id.table_name);
+        }
+    }
+    else if (auto * table_expr = ast->as<ASTTableExpression>())
+    {
+        if (table_expr->database_and_table_name)
+        {
+            DatabaseAndTableWithAlias db_and_table(table_expr->database_and_table_name);
+
+            auto database = db_and_table.database.empty() ? context->getCurrentDatabase() : db_and_table.database;
+            storage_infos.databases.push_back(database);
+            storage_infos.tables.push_back(database + "." + db_and_table.table);
+        }
+    }
+    /// XXX: This is a hack solution for an uncommonn query `SELECT ... WHERE x IN table`
+    /// which may cause some rare bugs if the identifiers confict with table names.
+    /// But I don't want to make the problem complex ..
+    else if (auto * func_expr = ast->as<ASTFunction>())
+    {
+        if (func_expr->arguments && func_expr->arguments->children.size() == 2 && (func_expr->name == "in" || func_expr->name == "notIn"))
+        {
+            auto * id = func_expr->arguments->children.back()->as<ASTIdentifier>();
+            if (id && id->nameParts().size() <= 2)
+            {
+                String database = id->nameParts().empty() ? "" : id->nameParts().front();
+                String table = id->nameParts().empty() ? id->name() : id->nameParts().back();
+                storage_infos.databases.push_back(database);
+                storage_infos.tables.push_back(database + "." + table);
+            }
+        }
+    }
+    else if (auto * refresh_mv = ast->as<ASTRefreshQuery>())
+    {
+        auto storage = database_catalog.tryGetTable(StorageID(refresh_mv->database, refresh_mv->table), context);
+        auto * view_table = dynamic_cast<StorageMaterializedView *>(storage.get());
+        if (view_table)
+        {
+            storage_infos.databases.push_back(refresh_mv->database);
+            storage_infos.tables.push_back(refresh_mv->database + "." + refresh_mv->table);
+        }
+    }
+
+    for (auto & child : ast->children)
+    {
+        tryGetStorageFromAST(child, context, storage_infos);
+    }
+}
+
+void enqueueVirtualWarehouseQueue(ContextMutablePtr context, ASTPtr & query_ast)
+{
+    ASTType ast_type;
+    try
+    {
+        ast_type = query_ast->getType();
+    }
+    catch (...)
+    {
+        LOG_DEBUG(&Poco::Logger::get("VirtualWarehouseQueue"), "only queue dml query");
+        return;
+    }
+    if (ast_type != ASTType::ASTSelectQuery && ast_type != ASTType::ASTSelectWithUnionQuery && ast_type != ASTType::ASTInsertQuery
+        && ast_type != ASTType::ASTDeleteQuery && ast_type != ASTType::ASTUpdateQuery)
+    {
+        LOG_DEBUG(&Poco::Logger::get("VirtualWarehouseQueue"), "only queue dml query");
+        return;
+    }
+    auto vw_handle = context->tryGetCurrentVW();
+    if (vw_handle && context->getSettingsRef().vw_queue_mode != VWQueueMode::Skip)
+    {
+        Stopwatch queue_watch;
+        queue_watch.start();
+        auto query_id = context->getCurrentQueryId();
+        auto vw_queue_info = std::make_shared<VWQueueInfo>(context->getCurrentQueryId(), context);
+        StorageInfos storage_infos;
+        tryGetStorageFromAST(query_ast, context, storage_infos);
+        std::copy(storage_infos.databases.begin(), storage_infos.databases.end(), std::back_inserter(vw_queue_info->query_rule.databases));
+        std::copy(storage_infos.tables.begin(), storage_infos.tables.end(), std::back_inserter(vw_queue_info->query_rule.tables));
+        vw_queue_info->query_rule.query_id = context->getCurrentQueryId();
+        vw_queue_info->query_rule.user = context->getClientInfo().current_user;
+        vw_queue_info->query_rule.ip = context->getClientInfo().current_address.toString();
+        if (query_ast)
+        {
+            auto fingerprint = SQLFingerprint().generateMD5(query_ast);
+            LOG_TRACE(&Poco::Logger::get("VirtualWarehouseQueueManager"), "sql : fingerprint is {}", fingerprint);
+            vw_queue_info->query_rule.fingerprint = fingerprint;
+        }
+        auto queue_result = vw_handle->enqueue(vw_queue_info, context->getSettingsRef().vw_query_queue_timeout_ms);
+
+        ProfileEvents::increment(ProfileEvents::VWQueueMilliseconds, queue_watch.elapsedMilliseconds());
+        if (queue_result == VWQueueResultStatus::QueueSuccess)
+        {
+            LOG_DEBUG(
+                &Poco::Logger::get("VirtualWarehouseQueueManager"), "query queue run time : {} ms", queue_watch.elapsedMilliseconds());
+        }
+        else
+        {
+            LOG_ERROR(
+                &Poco::Logger::get("VirtualWarehouseQueueManager"), "query queue result : {}", VWQueueResultStatusToString(queue_result));
+            throw Exception(
+                ErrorCodes::CNCH_QUEUE_QUERY_FAILURE,
+                "query queue failed for query_id {}: {}",
+                query_id,
+                VWQueueResultStatusToString(queue_result));
+        }
+    }
+}
+
+String queueRuleToString(const ResourceManagement::QueueRule & queue_rule)
+{
+    std::stringstream ss;
+    ss << "rule_name : " << queue_rule.rule_name << '\t';
+    for (const auto & db : queue_rule.databases)
+        ss << "db : " << db << '\t';
+    for (const auto & table : queue_rule.tables)
+        ss << "table : " << table << '\t';
+    ss << "ip : " << queue_rule.ip << "\tuser : " << queue_rule.user << "\tquery_id : " << queue_rule.query_id
+       << "\tfingerprint : " << queue_rule.fingerprint;
+    return ss.str();
+}
+
+String queueDataToString(const ResourceManagement::QueueData & queue_data)
+{
+    std::stringstream ss;
+    ss << "queue name : " << queue_data.queue_name << '\t';
+    ss << "max_concurrency " << queue_data.max_concurrency << '\t';
+    ss << "query_queue_size " << queue_data.query_queue_size << '\t';
+    for (const auto & rule : queue_data.queue_rules)
+    {
+        ss << queueRuleToString(rule);
+    }
+    return ss.str();
+}
+
+const char * VWQueueResultStatusToString(VWQueueResultStatus status)
+{
+    switch (status)
+    {
+        case VWQueueResultStatus::QueueSuccess:
+            return "QueueSuccess";
+        case VWQueueResultStatus::QueueCancel:
+            return "QueueCancel";
+        case VWQueueResultStatus::QueueFailed:
+            return "QueueFailed";
+        case VWQueueResultStatus::QueueOverSize:
+            return "QueueOverSize";
+        case VWQueueResultStatus::QueueStop:
+            return "QueueStop";
+        case VWQueueResultStatus::QueueTimeOut:
+            return "QueueTimeOut";
+        default:
+            return "QueueUnkown";
+    }
+}
+
+DequeueRelease::~DequeueRelease()
+{
+    for (auto & [queue_ptr, count] : enqueue_counts)
+        queue_ptr->dequeue(count);
+}
+
+void VirtualWarehouseQueue::init(const std::string & queue_name_)
+{
+    queue_name = queue_name_;
+}
+
+VWQueueResultStatus VirtualWarehouseQueue::enqueue(VWQueueInfoPtr queue_info, UInt64 timeout_ms)
+{
+    std::unique_lock lk(mutex);
+    LOG_DEBUG(log, "process query {}, current parallel : {}, max {}", queue_info->query_id, current_parallelize_size, max_concurrency);
+    if (max_concurrency == 0 || is_stop)
+    {
+        queue_info->result = VWQueueResultStatus::QueueFailed;
+        return VWQueueResultStatus::QueueFailed;
+    }
+    if (vw_query_queue.size() == query_queue_size)
+    {
+        return VWQueueResultStatus::QueueOverSize;
+    }
+    if (current_parallelize_size < max_concurrency)
+    {
+        LOG_DEBUG(log, "query {} execute current {}, max {}", queue_info->query_id, current_parallelize_size, max_concurrency);
+        current_parallelize_size++;
+        auto & dequeue_ptr = queue_info->context->getDequeuePtr();
+        if (!dequeue_ptr)
+        {
+            dequeue_ptr = std::make_shared<DequeueRelease>();
+        }
+        dequeue_ptr->increase(this);
+        return VWQueueResultStatus::QueueSuccess;
+    }
+    else
+    {
+        vw_query_queue.push_back(queue_info);
+        LOG_DEBUG(log, "query {} enqueue, queue size : {}", queue_info->query_id, vw_query_queue.size());
+        if (queue_info->cv.wait_for(lk, std::chrono::milliseconds(timeout_ms)) == std::cv_status::timeout)
+        {
+            LOG_DEBUG(log, "query {} timeout", queue_info->query_id);
+            queue_info->result = VWQueueResultStatus::QueueTimeOut;
+            return VWQueueResultStatus::QueueTimeOut;
+        }
+    }
+    LOG_DEBUG(log, "end process query {}, current parallel : {}", queue_info->query_id, current_parallelize_size);
+    return queue_info->result;
+}
+
+void VirtualWarehouseQueue::dequeue(size_t enqueue_count)
+{
+    std::unique_lock lk(mutex);
+    if (current_parallelize_size >= enqueue_count)
+        current_parallelize_size -= enqueue_count;
+    else
+        current_parallelize_size = 0;
+    LOG_DEBUG(log, "dequeue {}, current parallel : {}, max: {}", enqueue_count, current_parallelize_size, max_concurrency);
+    if (current_parallelize_size < max_concurrency && !is_stop)
+    {
+        size_t size = max_concurrency - current_parallelize_size;
+        while (size && !vw_query_queue.empty())
+        {
+            auto iter = vw_query_queue.begin();
+            if ((*iter)->result == VWQueueResultStatus::QueueTimeOut)
+            {
+                LOG_DEBUG(log, "query {} timeout", (*iter)->query_id);
+                vw_query_queue.pop_front();
+                continue;
+            }
+            size--;
+            current_parallelize_size++;
+            LOG_DEBUG(
+                log,
+                "trigger query {}, current parallel : {} query_size : {}",
+                (*iter)->query_id,
+                current_parallelize_size,
+                vw_query_queue.size());
+            auto & dequeue_ptr = (*iter)->context->getDequeuePtr();
+            if (!dequeue_ptr)
+            {
+                dequeue_ptr = std::make_shared<DequeueRelease>();
+            }
+            dequeue_ptr->increase(this);
+            (*iter)->cv.notify_one();
+            vw_query_queue.pop_front();
+        }
+    }
+    LOG_DEBUG(log, "end dequeue, current parallel : {}", current_parallelize_size);
+}
+
+void VirtualWarehouseQueue::shutdown()
+{
+    std::unique_lock lk(mutex);
+    is_stop = true;
+    for (auto iter = vw_query_queue.begin(); iter != vw_query_queue.end();)
+    {
+        (*iter)->result = VWQueueResultStatus::QueueStop;
+        (*iter)->cv.notify_one();
+        iter = vw_query_queue.erase(iter);
+    }
+}
+
+void VirtualWarehouseQueue::updateQueue(const ResourceManagement::QueueData & queue_data)
+{
+    {
+        std::unique_lock<std::shared_mutex> lock(rule_mutex);
+        LOG_TRACE(log, "updateQueue {}", queueDataToString(queue_data));
+        rules.clear();
+        for (const auto & rule : queue_data.queue_rules)
+            rules.push_back(rule);
+    }
+
+    std::unique_lock lk(mutex);
+    max_concurrency = queue_data.max_concurrency;
+    query_queue_size = queue_data.query_queue_size;
+}
+
+size_t VirtualWarehouseQueue::matchRules(const ResourceManagement::QueueRule & query_rule)
+{
+    std::shared_lock<std::shared_mutex> lock(rule_mutex);
+    bool is_match = false;
+    size_t rule_weight_sum = 0;
+    for (const auto & rule : rules)
+    {
+        size_t rule_weight = 0;
+        is_match |= matchContainer(query_rule.databases, rule.databases, rule_weight)
+            && matchContainer(query_rule.tables, rule.tables, rule_weight)
+            && (rule.query_id_regex ? matchRegex(query_rule.query_id, rule.query_id_regex.get(), rule_weight) : true)
+            && matchString(query_rule.user, rule.user, rule_weight) && matchString(query_rule.ip, rule.ip, rule_weight)
+            && matchString(query_rule.fingerprint, rule.fingerprint, rule_weight);
+        LOG_DEBUG(log, "try to match rule {}, is_match {} rule_weight {}", rule.rule_name, is_match, rule_weight);
+        rule_weight_sum += rule_weight;
+    }
+    return is_match ? rule_weight_sum : 0;
+}
+
+void VirtualWarehouseQueueManager::init()
+{
+    for (size_t index = 0; index < static_cast<size_t>(QueueName::Count); index++)
+    {
+        query_queues[index].init(SettingFieldEnum<QueueName, SettingFieldQueueNameTraits>(static_cast<QueueName>(index)).toString());
+    }
+}
+
+void VirtualWarehouseQueueManager::updateQueue(const std::vector<ResourceManagement::QueueData> & queue_datas)
+{
+    for (const auto & queue_data : queue_datas)
+    {
+        LOG_TRACE(log, "update queue for {}", queue_data.queue_name);
+        for (auto & queue : query_queues)
+        {
+            if (queue.queueName() == queue_data.queue_name)
+            {
+                queue.updateQueue(queue_data);
+            }
+        }
+    }
+}
+
+VWQueueResultStatus VirtualWarehouseQueueManager::enqueue(VWQueueInfoPtr queue_info, UInt64 timeout_ms)
+{
+    if (is_stop)
+        return VWQueueResultStatus::QueueStop;
+
+    LOG_TRACE(log, "vw begin enqueue query_rule {}", queueRuleToString(queue_info->query_rule));
+
+    auto queue_name = queue_info->context->getSettingsRef().queue_name.value;
+    if (queue_name < QueueName::Count)
+    {
+        return query_queues[static_cast<size_t>(queue_name)].enqueue(queue_info, timeout_ms);
+    }
+    size_t max_rule_weight = 0;
+    std::optional<size_t> target_queue_index;
+    for (size_t index = 0; index < static_cast<size_t>(QueueName::Count); index++)
+    {
+        auto rule_weight = query_queues[index].matchRules(queue_info->query_rule);
+        if (rule_weight > max_rule_weight)
+        {
+            max_rule_weight = rule_weight;
+            target_queue_index = index;
+        }
+    }
+
+    if (!target_queue_index)
+    {
+        if (queue_info->context->getSettingsRef().vw_queue_mode == VWQueueMode::Match)
+            return VWQueueResultStatus::QueueSuccess;
+        LOG_DEBUG(log, "can't find target queue, use Normal queue");
+        target_queue_index = static_cast<size_t>(QueueName::Normal);
+    }
+
+    ProfileEvents::increment(ProfileEvents::VWQueueType, *target_queue_index);
+    auto result = query_queues[*target_queue_index].enqueue(queue_info, timeout_ms);
+    return result;
+}
+
+void VirtualWarehouseQueueManager::shutdown()
+{
+    is_stop = true;
+    for (auto & query_queue : query_queues)
+    {
+        query_queue.shutdown();
+    }
+}
+
+} // DB

--- a/src/Interpreters/VirtualWarehouseQueue.h
+++ b/src/Interpreters/VirtualWarehouseQueue.h
@@ -1,0 +1,163 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <memory>
+#include <optional>
+#include <shared_mutex>
+#include <unordered_map>
+#include <vector>
+#include <Core/SettingsEnums.h>
+#include <Interpreters/Context_fwd.h>
+#include <ResourceManagement/CommonData.h>
+#include <bthread/condition_variable.h>
+#include <bthread/mutex.h>
+#include <re2/re2.h>
+#include <Common/Stopwatch.h>
+#include <common/logger_useful.h>
+
+namespace DB
+{
+struct StorageInfos
+{
+    std::vector<String> databases;
+    std::vector<String> tables;
+};
+
+void tryGetStorageFromAST(const ASTPtr & ast, ContextMutablePtr & context, StorageInfos & storage_infos);
+
+void enqueueVirtualWarehouseQueue(ContextMutablePtr context, ASTPtr & query_ast);
+
+enum class VWQueueResultStatus : uint8_t
+{
+    QueueSuccess = 0,
+    QueueFailed,
+    QueueCancel,
+    QueueOverSize,
+    QueueStop,
+    QueueTimeOut
+};
+
+const char * VWQueueResultStatusToString(VWQueueResultStatus status);
+class VirtualWarehouseQueue;
+struct DequeueRelease
+{
+    DequeueRelease() = default;
+    ~DequeueRelease();
+    void increase(VirtualWarehouseQueue * queue) { enqueue_counts[queue]++; }
+
+    std::unordered_map<VirtualWarehouseQueue *, size_t> enqueue_counts;
+};
+
+using DequeueReleasePtr = std::shared_ptr<DequeueRelease>;
+struct VWQueueInfo
+{
+    VWQueueInfo(const String & qid, ContextMutablePtr context_) : query_id(qid), context(context_) { enqueue_time = time(nullptr); }
+    VWQueueInfo() = default;
+    String query_id;
+    std::atomic<VWQueueResultStatus> result{VWQueueResultStatus::QueueSuccess};
+    bthread::ConditionVariable cv;
+    ContextMutablePtr context;
+    time_t enqueue_time{};
+    Stopwatch sw;
+    ResourceManagement::QueueRule query_rule;
+};
+using VWQueueInfoPtr = std::shared_ptr<VWQueueInfo>;
+using VWQueryQueue = std::deque<VWQueueInfoPtr>;
+
+struct QueueRuleWithRegex : public ResourceManagement::QueueRule
+{
+    QueueRuleWithRegex(const ResourceManagement::QueueRule & rule) : ResourceManagement::QueueRule(rule)
+    {
+        if (!rule.query_id.empty())
+            query_id_regex = std::make_shared<RE2>(rule.query_id);
+    }
+    std::shared_ptr<RE2> query_id_regex;
+};
+
+using QueueRuleWithRegexVec = std::vector<QueueRuleWithRegex>;
+class VirtualWarehouseQueue
+{
+public:
+    VirtualWarehouseQueue() : log(&Poco::Logger::get("VirtualWarehouseQueue")) { }
+    ~VirtualWarehouseQueue() { shutdown(); }
+    void init(const std::string & queue_name_);
+    void shutdown();
+    void dequeue(size_t enqueue_time);
+    VWQueueResultStatus enqueue(VWQueueInfoPtr queue_info, UInt64 timeout_ms);
+
+    std::string queueName() const
+    {
+        std::shared_lock<std::shared_mutex> lock(rule_mutex);
+        return queue_name;
+    }
+    size_t matchRules(const ResourceManagement::QueueRule & query_rule);
+
+    void updateQueue(const ResourceManagement::QueueData & queue_data);
+
+    size_t maxConcurrency() const
+    {
+        std::unique_lock lk(mutex);
+        return max_concurrency;
+    }
+
+    size_t queryQueueSize() const
+    {
+        std::unique_lock lk(mutex);
+        return query_queue_size;
+    }
+
+    QueueRuleWithRegexVec getRules() const
+    {
+        std::shared_lock<std::shared_mutex> lock(rule_mutex);
+        return rules;
+    }
+    template <class F>
+    void fillSystemTable(F && call)
+    {
+        call(*this);
+    }
+
+private:
+    mutable bthread::Mutex mutex;
+    bool is_stop{false};
+    size_t query_queue_size{200};
+    size_t max_concurrency{100};
+    size_t current_parallelize_size{0};
+    VWQueryQueue vw_query_queue;
+    Poco::Logger * log;
+
+    //rules
+    mutable std::shared_mutex rule_mutex;
+    QueueRuleWithRegexVec rules;
+    std::string queue_name;
+};
+
+
+class VirtualWarehouseQueueManager
+{
+public:
+    void init();
+
+    VirtualWarehouseQueueManager() : log(&Poco::Logger::get("VirtualWarehouseQueueManager")) { init(); }
+    ~VirtualWarehouseQueueManager() { shutdown(); }
+    void shutdown();
+    void updateQueue(const std::vector<ResourceManagement::QueueData> & queue_datas);
+    VWQueueResultStatus enqueue(VWQueueInfoPtr queue_info, UInt64 timeout_ms);
+
+    template <class F>
+    void fillSystemTable(F && call)
+    {
+        for (auto & queue : query_queues)
+        {
+            queue.fillSystemTable(call);
+        }
+    }
+
+private:
+    std::array<VirtualWarehouseQueue, static_cast<size_t>(QueueName::Count)> query_queues;
+    std::atomic<bool> is_stop{false};
+    Poco::Logger * log;
+};
+
+} // namespace DB

--- a/src/Parsers/ASTAlterWarehouseQuery.cpp
+++ b/src/Parsers/ASTAlterWarehouseQuery.cpp
@@ -46,11 +46,37 @@ void ASTAlterWarehouseQuery::formatImpl(const FormatSettings &s, FormatState &st
                       << (s.hilite ? hilite_none : "");
     }
 
+    if (type == Type::ADD_RULE)
+    {
+        s.ostr << " ADD RULE ";
+    }
+    else if (type == Type::DELETE_RULE)
+    {
+        s.ostr << " DELETE RULE "; 
+    }
+    else if (type == Type::MODIFY_RULE)
+    {
+        s.ostr << " MODIFY RULE ";
+    }
+
+    if (assignment_list)
+    {
+        s.ostr << " SET ";
+        assignment_list->formatImpl(s, state, frame);
+    }
+
+    if (predicate)
+    {
+        s.ostr << " WHERE ";
+        predicate->formatImpl(s, state, frame);
+    }
+    //todo format
     if (settings)
     {
         s.ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << "SETTINGS " << (s.hilite ? hilite_none : "");
         settings->formatImpl(s, state, frame);
     }
+
 }
 
 }

--- a/src/Parsers/ASTAlterWarehouseQuery.h
+++ b/src/Parsers/ASTAlterWarehouseQuery.h
@@ -26,8 +26,19 @@ class ASTAlterWarehouseQuery: public IAST
 {
 public:
 
+    enum Type 
+    {
+        UNKNOWN,
+        ADD_RULE,
+        DELETE_RULE,
+        MODIFY_RULE
+    };
+
     String name;
     String rename_to;
+    Type type {Type::UNKNOWN};
+    ASTPtr predicate;
+    ASTPtr assignment_list;
     String getID(char) const override { return "AlterWarehouseQuery"; }
 
     ASTSetQuery * settings = nullptr;
@@ -35,6 +46,8 @@ public:
     ASTPtr clone() const override;
 
     void formatImpl(const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const override;
+
+    ASTType getType() const override { return ASTType::ASTAlterCommand; }
 
 };
 }

--- a/src/Parsers/ParserAlterWarehouseQuery.h
+++ b/src/Parsers/ParserAlterWarehouseQuery.h
@@ -27,6 +27,9 @@ namespace DB
  * [MIN_CLUSTER_COUNT = <num>,]
  * [WORKER_COUNT = <num>,]
  * [MAX_CONCURRENCY_LEVEL = num]
+ * [DELETE RULE where rule_name = <rule> and queue_name = <queue>]
+ * [ADD RULE rule_name set database = [<db>], table = [<table>] WHERE queue_name = <queue>]
+ * [MODIFY RULE  set max_concurrency = <size> WHERE queue_name = <queue>]
  */
 class ParserAlterWarehouseQuery : public IParserBase
 {

--- a/src/Parsers/SQLFingerprint.cpp
+++ b/src/Parsers/SQLFingerprint.cpp
@@ -41,6 +41,18 @@ String SQLFingerprint::generate(
     return fingerprint_md5_str;
 }
 
+String SQLFingerprint::generateMD5(ASTPtr & ast)
+{
+    auto ast_str = generate(ast);
+    Poco::MD5Engine md5;
+    Poco::DigestOutputStream outstr(md5);
+    outstr << ast_str;
+    outstr.flush();
+    String fingerprint_md5_str = Poco::DigestEngine::digestToHex(md5.digest());
+
+    return fingerprint_md5_str;
+}
+
 String SQLFingerprint::generate(ASTPtr & ast)
 {
     SQLFingerprintRewriter rewriter;

--- a/src/Parsers/SQLFingerprint.h
+++ b/src/Parsers/SQLFingerprint.h
@@ -22,5 +22,6 @@ public:
         DialectType dialect_type = DialectType::CLICKHOUSE);
 
     String generate(ASTPtr & ast);
+    String generateMD5(ASTPtr & ast);
 };
 }

--- a/src/Protos/data_models.proto
+++ b/src/Protos/data_models.proto
@@ -391,6 +391,33 @@ message VirtualWarehouseSettings {
 
   optional uint32 cooldown_seconds_after_scaleup = 20;
   optional uint32 cooldown_seconds_after_scaledown = 21;
+
+  repeated QueueData queue_datas = 22;
+};
+
+enum QueueAlterType {
+  UNKNOWN = 0;
+  ADD_RULE = 1;
+  DELETE_RULE = 2;
+  MODIFY_RULE = 3;
+};
+
+message QueueRule {
+  optional string rule_name = 1;
+  repeated string databases = 2;
+  repeated string tables = 3;
+  optional string query_id = 4;
+  optional string user = 5;
+  optional string ip = 6;
+  optional string fingerprint = 7;
+};
+
+message QueueData {
+  //  highest = 0;  high = 1;   normal = 2;   low = 3;   lowest = 4;
+  optional string queue_name = 1;
+  optional uint32 max_concurrency = 2;
+  optional uint32 query_queue_size = 3;
+  repeated QueueRule queue_rules = 4;
 };
 
 message VirtualWarehouseAlterSettings {
@@ -417,7 +444,22 @@ message VirtualWarehouseAlterSettings {
   optional uint32 mem_threshold_for_recall = 19;
   optional uint32 cooldown_seconds_after_scaleup = 20;
   optional uint32 cooldown_seconds_after_scaledown = 21;
+  optional QueueAlterType queue_alter_type = 22;
+  optional QueueData queue_data = 23; 
+  optional uint32 max_concurrency = 24;
+  optional uint32 query_queue_size = 25;
+  optional string query_id = 26;
+  optional string user = 27;
+  optional string ip = 28;
+  optional string rule_name = 29;
+  optional bool has_table = 30;
+  repeated string tables = 31;
+  optional bool has_database = 32;
+  repeated string databases = 33;
+  optional string fingerprint = 34;
+  optional string queue_name = 35;
 };
+
 
 message VirtualWarehouseData {
   required string name = 1;
@@ -432,6 +474,8 @@ message VirtualWarehouseData {
 
   optional double cpu_usage_1min = 17;
   optional double memory_usage_1min = 18;
+
+  repeated QueueData queue_datas = 19;
 };
 
 // WorkNodeCatalogData

--- a/src/Protos/resource_manager_rpc.proto
+++ b/src/Protos/resource_manager_rpc.proto
@@ -130,6 +130,7 @@ message GetAllWorkersResp
 message GetWorkerGroupsReq
 {
     required string vw_name = 1;
+    optional uint64 last_settings_timestamp = 2;
 }
 
 
@@ -139,6 +140,8 @@ message GetWorkerGroupsResp
   optional string leader_host_port = 2;
   optional string exception = 3;
   repeated WorkerGroupData worker_group_data = 4;
+  optional VirtualWarehouseSettings vw_settings = 5;
+  optional uint64 last_settings_timestamp = 6;
 }
 
 message CreateWorkerGroupReq

--- a/src/ResourceManagement/CommonData.h
+++ b/src/ResourceManagement/CommonData.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
@@ -24,9 +25,11 @@
 #include <Common/HostWithPorts.h>
 #include <Core/Types.h>
 #include <Core/UUID.h>
+#include <Core/SettingsEnums.h>
 #include <ResourceManagement/VirtualWarehouseType.h>
 #include <ResourceManagement/VWScheduleAlgo.h>
 #include <ResourceManagement/WorkerGroupType.h>
+#include <Protos/data_models.pb.h>
 
 namespace DB
 {
@@ -49,6 +52,31 @@ namespace DB::Protos
 
 namespace DB::ResourceManagement
 {
+
+struct QueueRule
+{
+    std::string rule_name;
+    std::vector<std::string> databases;
+    std::vector<std::string> tables;
+    std::string query_id;
+    std::string user;
+    std::string ip;
+    std::string fingerprint;
+
+    void fillProto(Protos::QueueRule & queue_rule) const;
+    void parseFromProto(const Protos::QueueRule & queue_rule);
+};
+
+struct QueueData
+{
+    std::string queue_name;
+    size_t max_concurrency{100};
+    size_t query_queue_size{200};
+    std::vector<QueueRule> queue_rules;
+
+    void fillProto(Protos::QueueData & queue_data) const;
+    void parseFromProto(const Protos::QueueData & queue_data);
+};
 
 struct VirtualWarehouseSettings
 {
@@ -85,6 +113,8 @@ struct VirtualWarehouseSettings
     size_t cooldown_seconds_after_scaleup{300};
     size_t cooldown_seconds_after_scaledown{300};
 
+    std::vector<QueueData> queue_datas;
+
     void fillProto(Protos::VirtualWarehouseSettings & pb_settings) const;
     void parseFromProto(const Protos::VirtualWarehouseSettings & pb_settings);
 
@@ -119,6 +149,22 @@ struct VirtualWarehouseAlterSettings
     std::optional<size_t> cooldown_seconds_after_scaleup;
     std::optional<size_t> cooldown_seconds_after_scaledown;
 
+    Protos::QueueAlterType queue_alter_type {Protos::QueueAlterType::UNKNOWN};
+    std::optional<size_t> max_concurrency;
+    std::optional<size_t> query_queue_size;
+    std::optional<String> query_id;
+    std::optional<String> user;
+    std::optional<String> ip;
+    std::optional<String> rule_name;
+    std::optional<String> fingerprint;
+    std::optional<String> queue_name;
+    bool has_table {false};
+    bool has_database {false};
+    std::vector<String> tables;
+    std::vector<String> databases;
+
+    std::optional<QueueData> queue_data;
+
     void fillProto(Protos::VirtualWarehouseAlterSettings & pb_settings) const;
     void parseFromProto(const Protos::VirtualWarehouseAlterSettings & pb_settings);
 
@@ -129,7 +175,6 @@ struct VirtualWarehouseAlterSettings
         return vw_settings;
     }
 };
-
 struct VirtualWarehouseData
 {
     /// constants

--- a/src/ResourceManagement/ResourceManagerClient.cpp
+++ b/src/ResourceManagement/ResourceManagerClient.cpp
@@ -161,6 +161,7 @@ void ResourceManagerClient::updateVirtualWarehouse(const std::string & vw_name, 
 	{
         request.set_vw_name(vw_name);
         alter_settings.fillProto(*request.mutable_vw_settings());
+        LOG_TRACE(log, "update warehouse request : {}", request.ShortDebugString());
 
         stub_->updateVirtualWarehouse(&cntl, &request, &response, nullptr);
 
@@ -254,14 +255,19 @@ void ResourceManagerClient::dropWorkerGroup(const String & worker_group_id, bool
     callToLeaderWrapper(response, rpc_func);
 }
 
-void ResourceManagerClient::getWorkerGroups(const std::string & vw_name, std::vector<WorkerGroupData> & groups_data)
+void ResourceManagerClient::getWorkerGroups(
+    const std::string & vw_name,
+    std::vector<WorkerGroupData> & groups_data,
+    std::optional<VirtualWarehouseSettings> & settings,
+    std::atomic<UInt64> & last_settings_timestamp)
 {
     brpc::Controller cntl;
     Protos::GetWorkerGroupsReq request;
     Protos::GetWorkerGroupsResp response;
-    auto rpc_func = [this, &cntl, &request, &response, &vw_name](std::unique_ptr<Stub> & stub_)
+    auto rpc_func = [this, &cntl, &request, &response, &vw_name, &last_settings_timestamp](std::unique_ptr<Stub> & stub_)
 	{
         request.set_vw_name(vw_name);
+        request.set_last_settings_timestamp(last_settings_timestamp.load());
         stub_->getWorkerGroups(&cntl, &request, &response, nullptr);
         LOG_TRACE(
             &Poco::Logger::get("adaptiveScheduler"),
@@ -270,11 +276,17 @@ void ResourceManagerClient::getWorkerGroups(const std::string & vw_name, std::ve
         RPCHelpers::checkResponse(response);
     };
 
-    auto process_response = [&groups_data] (Protos::GetWorkerGroupsResp & response_)
+    auto process_response = [&groups_data, &settings, &last_settings_timestamp] (Protos::GetWorkerGroupsResp & response_)
     {
         for (auto & worker_group_data : response_.worker_group_data())
         {
             groups_data.emplace_back(WorkerGroupData::createFromProto(worker_group_data));
+        }
+        if (response_.has_vw_settings())
+        {
+            settings = VirtualWarehouseSettings{};
+            (*settings).parseFromProto(response_.vw_settings());
+            last_settings_timestamp = response_.last_settings_timestamp();
         }
     };
 

--- a/src/ResourceManagement/ResourceManagerClient.h
+++ b/src/ResourceManagement/ResourceManagerClient.h
@@ -23,6 +23,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/Context_fwd.h>
 #include <Poco/Util/AbstractConfiguration.h>
+#include <Protos/resource_manager_rpc.pb.h>
 
 namespace DB
 {
@@ -66,7 +67,7 @@ public:
     std::vector<WorkerGroupData> getAllWorkerGroups(bool with_metrics = false);
 
     void getAllWorkers(std::vector<WorkerNodeResourceData> & data);
-    void getWorkerGroups(const std::string & vw_name, std::vector<WorkerGroupData> & groups_data);
+    void getWorkerGroups(const std::string & vw_name, std::vector<WorkerGroupData> & groups_data, std::optional<VirtualWarehouseSettings> & settings, std::atomic<UInt64> & last_settings_timestamp);
     bool reportResourceUsage(const WorkerNodeResourceData & data);
 
     void registerWorker(const WorkerNodeResourceData & data);

--- a/src/ResourceManagement/VirtualWarehouse.cpp
+++ b/src/ResourceManagement/VirtualWarehouse.cpp
@@ -14,23 +14,22 @@
  */
 
 #include <Catalog/Catalog.h>
-#include <Common/Exception.h>
 #include <ResourceManagement/VirtualWarehouse.h>
+#include <Common/Exception.h>
+#include "ResourceManagement/CommonData.h"
 
 #include <chrono>
 
 namespace DB::ErrorCodes
 {
-    extern const int RESOURCE_MANAGER_ERROR;
-    extern const int RESOURCE_MANAGER_INCORRECT_SETTING;
-    extern const int RESOURCE_MANAGER_NO_AVAILABLE_WORKER_GROUP;
+extern const int RESOURCE_MANAGER_ERROR;
+extern const int RESOURCE_MANAGER_INCORRECT_SETTING;
+extern const int RESOURCE_MANAGER_NO_AVAILABLE_WORKER_GROUP;
 }
 
 namespace DB::ResourceManagement
 {
-
-VirtualWarehouse::VirtualWarehouse(String n, UUID u, const VirtualWarehouseSettings & s)
-    : name(std::move(n)), uuid(u), settings(s)
+VirtualWarehouse::VirtualWarehouse(String n, UUID u, const VirtualWarehouseSettings & s) : name(std::move(n)), uuid(u), settings(s)
 {
     query_scheduler = std::make_unique<QueryScheduler>(*this);
 }
@@ -44,8 +43,7 @@ void VirtualWarehouse::applySettings(const VirtualWarehouseAlterSettings & setti
         new_settings.type = *setting_changes.type;
     if (setting_changes.max_worker_groups)
     {
-        if ((setting_changes.min_worker_groups
-                && setting_changes.min_worker_groups.value() > setting_changes.max_worker_groups.value())
+        if ((setting_changes.min_worker_groups && setting_changes.min_worker_groups.value() > setting_changes.max_worker_groups.value())
             || (!setting_changes.min_worker_groups && settings.min_worker_groups > setting_changes.max_worker_groups.value()))
             throw Exception("min_worker_groups cannot be less than max_worker_groups", ErrorCodes::RESOURCE_MANAGER_INCORRECT_SETTING);
         new_settings.max_worker_groups = *setting_changes.max_worker_groups;
@@ -91,9 +89,106 @@ void VirtualWarehouse::applySettings(const VirtualWarehouseAlterSettings & setti
     if (setting_changes.cooldown_seconds_after_scaledown)
         new_settings.cooldown_seconds_after_scaledown = *setting_changes.cooldown_seconds_after_scaledown;
 
+    LOG_TRACE(&Poco::Logger::get("VirtualWarehouse"), "update settings alter type {}", setting_changes.queue_alter_type);
+    if (setting_changes.queue_alter_type == Protos::QueueAlterType::ADD_RULE)
+    {
+        if (!setting_changes.queue_data)
+        {
+            throw Exception("Can't find queue_data when ADD_RULE", ErrorCodes::RESOURCE_MANAGER_ERROR);
+        }
+        auto queue_iter = std::find_if(new_settings.queue_datas.begin(), new_settings.queue_datas.end(), [&](const QueueData & queue_data) {
+            return queue_data.queue_name == setting_changes.queue_data->queue_name;
+        });
+        if (queue_iter == new_settings.queue_datas.end())
+        {
+            QueueData queue_data;
+            queue_data.queue_name = setting_changes.queue_data->queue_name;
+            std::copy(
+                setting_changes.queue_data->queue_rules.begin(),
+                setting_changes.queue_data->queue_rules.end(),
+                std::back_inserter(queue_data.queue_rules));
+            new_settings.queue_datas.push_back(queue_data);
+        }
+        else
+        {
+            std::copy(
+                setting_changes.queue_data->queue_rules.begin(),
+                setting_changes.queue_data->queue_rules.end(),
+                std::back_inserter(queue_iter->queue_rules));
+        }
+    }
+    else if (setting_changes.queue_alter_type == Protos::QueueAlterType::DELETE_RULE)
+    {
+        if (!setting_changes.queue_name || !setting_changes.rule_name)
+        {
+            throw Exception("Can't find queue_name or rule_name when DELETE_RULE", ErrorCodes::RESOURCE_MANAGER_ERROR);
+        }
+        auto queue_iter = std::find_if(new_settings.queue_datas.begin(), new_settings.queue_datas.end(), [&](const QueueData & queue_data) {
+            return queue_data.queue_name == *setting_changes.queue_name;
+        });
+        if (queue_iter != new_settings.queue_datas.end())
+        {
+            queue_iter->queue_rules.erase(
+                std::remove_if(
+                    queue_iter->queue_rules.begin(),
+                    queue_iter->queue_rules.end(),
+                    [&setting_changes](const QueueRule & rule) { return rule.rule_name == *setting_changes.rule_name; }),
+                queue_iter->queue_rules.end());
+        }
+    }
+    else if (setting_changes.queue_alter_type == Protos::QueueAlterType::MODIFY_RULE)
+    {
+        if (!setting_changes.queue_name)
+        {
+            throw Exception("Can't find queue_name when MODIFY_RULE", ErrorCodes::RESOURCE_MANAGER_ERROR);
+        }
+        auto queue_iter = std::find_if(new_settings.queue_datas.begin(), new_settings.queue_datas.end(), [&](const QueueData & queue_data) {
+            return queue_data.queue_name == *setting_changes.queue_name;
+        });
+        if (queue_iter != new_settings.queue_datas.end())
+        {
+            if (setting_changes.max_concurrency)
+                queue_iter->max_concurrency = *setting_changes.max_concurrency;
+            if (setting_changes.query_queue_size)
+                queue_iter->query_queue_size = *setting_changes.query_queue_size;
+            if (setting_changes.rule_name)
+            {
+                auto rule_iter = std::find_if(queue_iter->queue_rules.begin(), queue_iter->queue_rules.end(), [&](const QueueRule & rule) {
+                    return rule.rule_name == *setting_changes.rule_name;
+                });
+                if (rule_iter != queue_iter->queue_rules.end())
+                {
+                    if (setting_changes.query_id)
+                        rule_iter->query_id = *setting_changes.query_id;
+                    if (setting_changes.ip)
+                        rule_iter->ip = *setting_changes.ip;
+                    if (setting_changes.has_table)
+                        rule_iter->tables = setting_changes.tables;
+                    if (setting_changes.has_database)
+                        rule_iter->databases = setting_changes.databases;
+                    if (setting_changes.user)
+                        rule_iter->user = *setting_changes.user;
+                    if (setting_changes.fingerprint)
+                        rule_iter->fingerprint = *setting_changes.fingerprint;
+                }
+            }
+        }
+        else
+        {
+            QueueData queue_data;
+            queue_data.queue_name = *setting_changes.queue_name;
+            if (setting_changes.max_concurrency)
+                queue_iter->max_concurrency = *setting_changes.max_concurrency;
+            if (setting_changes.query_queue_size)
+                queue_iter->query_queue_size = *setting_changes.query_queue_size;
+            new_settings.queue_datas.push_back(queue_data);
+        }
+    }
+
     catalog->alterVirtualWarehouse(name, data);
     {
         auto wlock = getWriteLock();
+        last_settings_timestamp = time(nullptr);
         settings = new_settings;
     }
 }
@@ -122,7 +217,7 @@ std::vector<WorkerGroupPtr> VirtualWarehouse::getAllWorkerGroups() const
 
     auto rlock = getReadLock();
 
-    for (const auto & [_, group]: groups)
+    for (const auto & [_, group] : groups)
         res.emplace_back(group);
 
     return res;
@@ -134,7 +229,7 @@ std::vector<WorkerGroupPtr> VirtualWarehouse::getNonborrowedGroups() const
 
     auto rlock = getReadLock();
 
-    for (const auto & [_, group]: groups)
+    for (const auto & [_, group] : groups)
     {
         if (borrowed_groups.find(group->getID()) == borrowed_groups.end())
             res.emplace_back(group);
@@ -204,36 +299,36 @@ void VirtualWarehouse::loadGroup(const WorkerGroupPtr & group)
 
 void VirtualWarehouse::lendGroup(const String & id)
 {
-   auto wlock = getWriteLock();
+    auto wlock = getWriteLock();
 
-   // Update lend count of group
-   auto it = lent_groups.find(id);
+    // Update lend count of group
+    auto it = lent_groups.find(id);
 
-   if (it != lent_groups.end())
-   {
-       it->second += 1;
-   }
-   else
-   {
-       lent_groups[id] = 1;
-   }
+    if (it != lent_groups.end())
+    {
+        it->second += 1;
+    }
+    else
+    {
+        lent_groups[id] = 1;
+    }
 }
 
 void VirtualWarehouse::unlendGroup(const String & id)
 {
-   auto wlock = getWriteLock();
-   auto it = lent_groups.find(id);
-   if (it == lent_groups.end())
-   {
-       throw Exception("Lent group " + id + " does not exist in VW " + name, ErrorCodes::LOGICAL_ERROR);
-   }
-   else
-   {
-       if (it->second == 1)
-           lent_groups.erase(it); // Erase group from lent groups if this is the last link
-       else
-           it->second -= 1;
-   }
+    auto wlock = getWriteLock();
+    auto it = lent_groups.find(id);
+    if (it == lent_groups.end())
+    {
+        throw Exception("Lent group " + id + " does not exist in VW " + name, ErrorCodes::LOGICAL_ERROR);
+    }
+    else
+    {
+        if (it->second == 1)
+            lent_groups.erase(it); // Erase group from lent groups if this is the last link
+        else
+            it->second -= 1;
+    }
 }
 
 size_t VirtualWarehouse::getNumBorrowedGroups() const
@@ -379,8 +474,7 @@ QueryQueueInfo VirtualWarehouse::getAggQueueInfo()
 {
     std::lock_guard lock(queue_map_mutex);
 
-    UInt64 time_now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()
-                                                                            .time_since_epoch()).count();
+    UInt64 time_now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     // TODO: Use setting vw_queue_server_sync_expiry_seconds
     auto timeout = 15;
     auto timeout_threshold = time_now - timeout * 1000;
@@ -394,9 +488,11 @@ QueryQueueInfo VirtualWarehouse::getAggQueueInfo()
         //Remove outdated entries
         if (it->second.last_sync < timeout_threshold)
         {
-            LOG_DEBUG(&Poco::Logger::get("VirtualWarehouse"),
-                        "Removing outdated server sync from {}, last synced {}",
-                        it->first, std::to_string(it->second.last_sync));
+            LOG_DEBUG(
+                &Poco::Logger::get("VirtualWarehouse"),
+                "Removing outdated server sync from {}, last synced {}",
+                it->first,
+                std::to_string(it->second.last_sync));
             it = server_query_queue_map.erase(it);
         }
         else

--- a/src/ResourceManagement/VirtualWarehouse.h
+++ b/src/ResourceManagement/VirtualWarehouse.h
@@ -20,6 +20,7 @@
 #include <ResourceManagement/QueryScheduler.h>
 #include <ResourceManagement/SharedWorkerGroup.h>
 #include <Common/Config/ConfigProcessor.h>
+#include <Protos/resource_manager_rpc.pb.h>
 
 #include <vector>
 #include <map>
@@ -111,6 +112,8 @@ public:
     void setLastBorrowTimestamp(UInt64 last_borrow_timestamp_) { last_borrow_timestamp = last_borrow_timestamp_; }
     void setLastLendTimestamp(UInt64 last_lend_timestamp_) { last_lend_timestamp = last_lend_timestamp_; }
 
+    UInt64 getLastSettingsTimestamp() const { return last_settings_timestamp.load(); }
+
 private:
     const WorkerGroupPtr & getWorkerGroupImpl(const String & id, ReadLock & rlock);
     const WorkerGroupPtr & getWorkerGroupExclusiveImpl(const String & id, WriteLock & wlock);
@@ -139,6 +142,8 @@ private:
     std::unordered_map<String, size_t> lent_groups; // Map of group_id to lend count
     UInt64 last_borrow_timestamp{0};
     UInt64 last_lend_timestamp{0};
+
+    std::atomic<UInt64> last_settings_timestamp{0};
 
     std::unique_ptr<QueryScheduler> query_scheduler;
 

--- a/src/Storages/System/StorageSystemVirtualWarehouseQueryQueue.cpp
+++ b/src/Storages/System/StorageSystemVirtualWarehouseQueryQueue.cpp
@@ -1,0 +1,90 @@
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/QueueManager.h>
+#include <Interpreters/VirtualWarehousePool.h>
+#include <Interpreters/VirtualWarehouseQueue.h>
+#include <Storages/System/StorageSystemVirtualWarehouseQueryQueue.h>
+
+namespace DB
+{
+
+NamesAndTypesList StorageSystemVirtualWarehouseQueryQueue::getNamesAndTypes()
+{
+    return {
+        {"virtual_warehouse", std::make_shared<DataTypeString>()},
+        {"queue_name", std::make_shared<DataTypeString>()},
+        {"max_concurrency", std::make_shared<DataTypeUInt64>()},
+        {"query_queue_size", std::make_shared<DataTypeUInt64>()},
+        {"rule_name", std::make_shared<DataTypeString>()},
+        {"databases", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>())},
+        {"tables", std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>())},
+        {"user", std::make_shared<DataTypeString>()},
+        {"ip", std::make_shared<DataTypeString>()},
+        {"query_id", std::make_shared<DataTypeString>()},
+        {"fingerprint", std::make_shared<DataTypeString>()}};
+}
+
+void StorageSystemVirtualWarehouseQueryQueue::fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo &) const
+{
+    auto all_vw = context->getVirtualWarehousePool().getAll();
+    for (auto iter = all_vw.begin(); iter != all_vw.end(); iter++)
+    {
+        iter->second->getQueueManager().fillSystemTable([&](VirtualWarehouseQueue & queue) {
+
+            const auto rules = queue.getRules();
+            if (rules.empty())
+            {
+                size_t i = 0;
+                res_columns[i++]->insert(iter->first);
+                res_columns[i++]->insert(queue.queueName());
+                res_columns[i++]->insert(queue.maxConcurrency());
+                res_columns[i++]->insert(queue.queryQueueSize());
+                DB::Array tmp;
+                res_columns[i++]->insert("");
+                res_columns[i++]->insert(tmp);
+                res_columns[i++]->insert(tmp);
+                res_columns[i++]->insert("");
+                res_columns[i++]->insert("");
+                res_columns[i++]->insert("");
+                res_columns[i++]->insert("");
+            }
+            else
+            {
+                for (const auto & rule : rules)
+                {
+                    size_t i = 0;
+                    res_columns[i++]->insert(iter->first);
+                    res_columns[i++]->insert(queue.queueName());
+                    res_columns[i++]->insert(queue.maxConcurrency());
+                    res_columns[i++]->insert(queue.queryQueueSize());
+                    res_columns[i++]->insert(rule.rule_name);
+                    DB::Array tmp;
+                    tmp.reserve(rule.databases.size());
+                    for (const auto & database : rule.databases)
+                    {
+                        tmp.emplace_back(database); 
+                    }
+                    res_columns[i++]->insert(tmp);
+
+                    tmp.clear();
+                    for (const auto & table : rule.tables)
+                    {
+                        tmp.emplace_back(table); 
+                    }
+                    res_columns[i++]->insert(tmp);
+                    res_columns[i++]->insert(rule.user);
+                    res_columns[i++]->insert(rule.ip);
+                    res_columns[i++]->insert(rule.query_id);
+                    res_columns[i++]->insert(rule.fingerprint);
+                }
+            }
+            
+
+        });
+    }
+}
+
+}

--- a/src/Storages/System/StorageSystemVirtualWarehouseQueryQueue.h
+++ b/src/Storages/System/StorageSystemVirtualWarehouseQueryQueue.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Storages/System/IStorageSystemOneBlock.h>
+#include <common/shared_ptr_helper.h>
+
+namespace DB
+{
+class Context;
+
+class StorageSystemVirtualWarehouseQueryQueue final : public shared_ptr_helper<StorageSystemVirtualWarehouseQueryQueue>,
+                                      public IStorageSystemOneBlock<StorageSystemVirtualWarehouseQueryQueue>
+{
+    friend struct shared_ptr_helper<StorageSystemVirtualWarehouseQueryQueue>;
+
+protected:
+    void fillData(MutableColumns & res_columns, ContextPtr context, const SelectQueryInfo & query_info) const override;
+
+    using IStorageSystemOneBlock::IStorageSystemOneBlock;
+
+public:
+    std::string getName() const override { return "SystemVirtualWarehouseQueryQueue"; }
+
+    static NamesAndTypesList getNamesAndTypes();
+};
+}

--- a/src/Storages/System/attachSystemTables.cpp
+++ b/src/Storages/System/attachSystemTables.cpp
@@ -74,6 +74,7 @@
 #include <Storages/System/StorageSystemKafkaTables.h>
 #include <Storages/System/StorageSystemCnchKafkaTables.h>
 #endif
+#include <Storages/System/StorageSystemVirtualWarehouseQueryQueue.h>
 #include <Storages/System/StorageSystemCnchTransactions.h>
 #include <Storages/System/StorageSystemCnchFilesystemLock.h>
 #include "Storages/System/StorageSystemExternalTables.h"
@@ -223,6 +224,7 @@ void attachSystemTablesServer(IDatabase & system_database, bool has_zookeeper)
     attach<StorageSystemStoragePolicies>(system_database, "storage_policies");
     attach<StorageSystemProcesses>(system_database, "processes");
     attach<StorageSystemQueryQueue>(system_database, "query_queue");
+    attach<StorageSystemVirtualWarehouseQueryQueue>(system_database, "virtual_warehouse_queue");
     attach<StorageSystemMetrics>(system_database, "metrics");
     attach<StorageSystemMerges>(system_database, "merges");
     attach<StorageSystemMutations>(system_database, "mutations");


### PR DESCRIPTION
fix: [cp] Undo buffer use reversed transaction id to avoid write increment keys to bytekv