### PR TITLE
fix: [cp] skip bad ttl when doing partition gc

### DIFF
--- a/src/CloudServices/CnchPartGCThread.cpp
+++ b/src/CloudServices/CnchPartGCThread.cpp
@@ -189,6 +189,8 @@ void CnchPartGCThread::tryMarkExpiredPartitions(StorageCnchMergeTree & storage, 
             }
         }
     }
+    if (partition_infos.empty())
+        return;
 
     ContextMutablePtr query_context = Context::createCopy(storage.getContext());
 
@@ -654,7 +656,16 @@ size_t CnchPartGCThread::doPhaseOnePartitionGC(const StoragePtr & istorage, Stor
 
     /// Generate DROP_RANGE for expired partitions by the TTL
     if (!visible_parts.empty())
-        tryMarkExpiredPartitions(storage, visible_parts);
+    {
+        try
+        {
+            tryMarkExpiredPartitions(storage, visible_parts);
+        }
+        catch(...)
+        {
+            LOG_DEBUG(log, "Failed to mark expired partitions, just skip.");
+        }
+    }
 
     /// Clear special old parts
     UInt64 old_parts_lifetime = in_wakeup ? 0ull : static_cast<UInt64>(storage_settings->old_parts_lifetime.totalSeconds());


### PR DESCRIPTION
fix: [cp] skip bad ttl when doing partition gc