### PR TITLE
fix: skip column size check for mutation & swallow the exception when submitting mutation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           ./build_bin.sh
       - name: run unit tests
         run: |
+          mkdir -p /test_output
           bash $GITHUB_WORKSPACE/unittest.sh
       - name: glibc_compatibility_check 
         run: |
@@ -77,7 +78,6 @@ jobs:
           sed -i "s|COMPOSE\_PROJECT\_NAME|${COMPOSE_PROJECT_NAME}|g" config_for_s3_storage/daemon-manager.yml
           echo "Create volumes for ByConity Cluster"
           /bin/bash create_docker_volume_ci.sh
-          mkdir -p /test_output
       - name: Create ByConity Cluster S3
         run: |
           echo "Bring up ByConity Cluster S3"

--- a/src/Storages/MergeTree/MergeTreeDataPartCNCH.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartCNCH.cpp
@@ -1055,7 +1055,9 @@ void MergeTreeDataPartCNCH::calculateEachColumnSizes(
         if (rows_count != 0 && column.type->isValueRepresentedByNumber() && !column.type->haveSubtypes())
         {
             size_t rows_in_column = size.data_uncompressed / column.type->getSizeOfValueInMemory();
-            if (rows_in_column != rows_count)
+            /// rows_in_column = 0 may indicate that the part don't contains the column 
+            /// (like running mutation task involved new columns on old parts).
+            if (rows_in_column != 0 && rows_in_column != rows_count)
             {
                 throw Exception(
                     ErrorCodes::LOGICAL_ERROR,

--- a/unittest.sh
+++ b/unittest.sh
@@ -7,5 +7,9 @@ fi
 
 UTESTS="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/build"
 cd $UTESTS
-src/unit_tests_dbms --output-on-failure
+if [ -d /test_output ]; then
+    src/unit_tests_dbms --output-on-failure |& tee /test_output/unittest.log 
+else
+    src/unit_tests_dbms --output-on-failure 
+fi
 


### PR DESCRIPTION
fix: skip column size check for mutation & swallow the exception when submitting mutation