### PR TITLE
fix: only push bitmapindex column to tablescan

### DIFF
--- a/src/Optimizer/Rewriter/BitmapIndexSplitter.cpp
+++ b/src/Optimizer/Rewriter/BitmapIndexSplitter.cpp
@@ -130,9 +130,10 @@ PlanNodePtr FuncSplitter::visitProjectionNode(ProjectionNode & node, SplitterCon
         }
         // split arraysetcheck func in projection
         Assignments array_set_check_func;
+        auto tname_to_type = new_node->getChildren()[0]->getCurrentDataStream().getNamesToTypes();
         for (const auto & item : projection_step->getAssignments())
         {
-            auto tmp_array_set_check_func = CollectFuncs::collect(item.second, new_node->getChildren()[0]->getCurrentDataStream().getNamesToTypes(), context);
+            auto tmp_array_set_check_func = CollectFuncs::collect(item.second, tname_to_type, context);
             for (const auto & it : tmp_array_set_check_func)
             {
                 if (!splitter_context.ast_to_name.contains(it.second))

--- a/src/Optimizer/Rule/Rewrite/PushProjectionRules.cpp
+++ b/src/Optimizer/Rule/Rewrite/PushProjectionRules.cpp
@@ -26,9 +26,11 @@ TransformResult PushProjectionThroughFilter::transformImpl(PlanNodePtr node, con
     auto * projection = dynamic_cast<const ProjectionStep *>(node->getStep().get());
 
     size_t func_count = 0;
+    
+    auto tname_to_type = node->getChildren()[0]->getCurrentDataStream().getNamesToTypes();
     for (const auto & item : projection->getAssignments())
     {
-        func_count += CollectFuncs::collect(item.second, node->getChildren()[0]->getCurrentDataStream().getNamesToTypes(), rule_context.context).size();
+        func_count += CollectFuncs::collect(item.second, tname_to_type, rule_context.context).size();
     }
 
     if (!func_count)
@@ -115,10 +117,11 @@ TransformResult PushProjectionThroughProjection::transformImpl(PlanNodePtr node,
     auto * projection = dynamic_cast<const ProjectionStep *>(node->getStep().get());
     auto * bottom_projection = dynamic_cast<const ProjectionStep *>(node->getChildren()[0]->getStep().get());
 
+    auto tname_to_type = node->getChildren()[0]->getCurrentDataStream().getNamesToTypes();
     size_t func_count = 0;
     for (const auto & item : projection->getAssignments())
     {
-        func_count += CollectFuncs::collect(item.second, node->getChildren()[0]->getCurrentDataStream().getNamesToTypes(), rule_context.context).size();
+        func_count += CollectFuncs::collect(item.second, tname_to_type, rule_context.context).size();
     }
 
     if (!func_count)


### PR DESCRIPTION
fix: only push bitmapindex column to tablescan