### PR TITLE
fix Chinese Tokenizer with like filter token

### DIFF
--- a/src/Common/ChineseTokenExtractor.cpp
+++ b/src/Common/ChineseTokenExtractor.cpp
@@ -143,7 +143,7 @@ void ChineseTokenExtractor::stringLikeToGinFilter(const String & data, ChineseTo
         begin_offset++;
         end_size--;
     }
-    if (data.starts_with("%"))
+    if (data.ends_with("%"))
     {
         end_size--;
     }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->

<!-- If you are doing this for the first time, it's recommended to read the lightweight Contributing to ByConity Documentation https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md guide first. -->

### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Bug Fix https://github.com/ByConity/ByConity/issues/1654



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix Chinese Tokenizer for like filter with '%' end

### Documentation entry for user-facing changes
For Using Chinese Tokenizer Inverted index , the inner '%' of like string is ignored and assumed as a token in string. 

<!---

Add a user-readable short description of the changes that should be added to https://github.com/ByConity/byconity.github.io below.

At a minimum, the following information should be added (but add more as needed).

- Motivation: Why is this function, table engine, etc. useful to ByConity users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
