### PR TITLE
sloved issues 1674  An error occurred when the daemon was connected t…

### DIFF
--- a/src/DaemonManager/DaemonManager.cpp
+++ b/src/DaemonManager/DaemonManager.cpp
@@ -252,6 +252,13 @@ int DaemonManager::main(const std::vector<std::string> &)
     std::string path = getCanonicalPath(config().getString("path", DBMS_DEFAULT_PATH));
     global_context->setPath(path);
 
+    /// Init HDFS3 client config path
+    std::string hdfs_config = global_context->getCnchConfigRef().getString("hdfs3_config", "");
+    if (!hdfs_config.empty())
+    {
+        setenv("LIBHDFS3_CONF", hdfs_config.c_str(), 1);
+    }
+
     HDFSConnectionParams hdfs_params = HDFSConnectionParams::parseHdfsFromConfig(global_context->getCnchConfigRef());
     global_context->setHdfsConnectionParams(hdfs_params);
 


### PR DESCRIPTION
sloved  1674: An error occurred when the daemon was connected to hdfs ha 

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->

<!-- If you are doing this for the first time, it's recommended to read the lightweight Contributing to ByConity Documentation https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md guide first. -->

### Changelog category <!-- please remove the below items and leave one that you choose -->:

- Bug Fix



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

After the Daemon Manager starts, it does not read the configuration information of LIBHDFS3_CONF from the environment variables, causing errors when enabling HDFS HA. This part is controlled by relevant code in the worker. Refer to the server and worker's code to add the corresponding configuration reading code.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---

Add a user-readable short description of the changes that should be added to https://github.com/ByConity/byconity.github.io below.

At a minimum, the following information should be added (but add more as needed).

- Motivation: Why is this function, table engine, etc. useful to ByConity users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
