### PR TITLE
Fix S3 segment upload file part file size cannot be configured

### DIFF
--- a/src/Disks/DiskByteS3.h
+++ b/src/Disks/DiskByteS3.h
@@ -41,7 +41,8 @@ public:
     friend class DiskByteS3Reservation;
 
     DiskByteS3(const String& name_, const String& root_prefix_, const String& bucket_,
-        const std::shared_ptr<Aws::S3::S3Client>& client_);
+        const std::shared_ptr<Aws::S3::S3Client>& client_,
+        const UInt64 min_upload_part_size_, const UInt64 max_single_part_upload_size_);
 
     virtual const String & getName() const override { return name; }
 
@@ -143,6 +144,9 @@ private:
     UInt64 reservation_count;
 
     static std::mutex reservation_mutex;
+
+    UInt64 min_upload_part_size;
+    UInt64 max_single_part_upload_size;
 };
 
 using DiskByteS3Ptr = std::shared_ptr<DiskByteS3>;

--- a/src/FormaterTool/PartWriter.cpp
+++ b/src/FormaterTool/PartWriter.cpp
@@ -163,7 +163,8 @@ void PartWriter::execute()
     {
         /// S3 remote disk.
         std::shared_ptr<Aws::S3::S3Client> client = s3_output_config->create();
-        remote_disk = std::make_shared<DiskByteS3>("s3_disk", s3_output_config->root_prefix, s3_output_config->bucket, client);
+        remote_disk = std::make_shared<DiskByteS3>("s3_disk", s3_output_config->root_prefix, s3_output_config->bucket, client,
+            s3_output_config->min_upload_part_size, s3_output_config->max_single_part_upload_size);
         s3_attach_meta = std::make_unique<S3PartsAttachMeta>(
             client, s3_output_config->bucket, std::filesystem::path(s3_output_config->root_prefix) / "", dest_path);
 

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -462,7 +462,9 @@ namespace S3
             ("s3.root_prefix", po::value<String>(&root_prefix)->required(), "root prefix")
             ("s3.is_virtual_hosted_style", po::value<bool>(&is_virtual_hosted_style)->default_value(false)->implicit_value(false), "is virtual hosted style or not")
             ("s3.http_keep_alive_timeout_ms", po::value<uint32_t>(&http_keep_alive_timeout_ms)->default_value(5000)->implicit_value(5000), "http keep alive time")
-            ("s3.http_connection_pool_size", po::value<size_t>(&http_connection_pool_size)->implicit_value(1024)->default_value(1024), "http pool size");
+            ("s3.http_connection_pool_size", po::value<size_t>(&http_connection_pool_size)->implicit_value(1024)->default_value(1024), "http pool size")
+            ("s3.min_upload_part_size", po::value<UInt64>(&min_upload_part_size)->implicit_value(16 * 1024 * 1024)->default_value(16 * 1024 * 1024), "min upload part size")
+            ("s3.max_single_part_upload_size", po::value<UInt64>(&max_single_part_upload_size)->implicit_value(16 * 1024 * 1024)->default_value(16 * 1024 * 1024), "max single part upload size");
 
         po::parsed_options opts = po::parse_config_file(ini_file_path.c_str(), s3_opts);
         po::variables_map vm;
@@ -515,6 +517,8 @@ namespace S3
         is_virtual_hosted_style = cfg.getBool(cfg_prefix + ".is_virtual_hosted_style", true);
         http_keep_alive_timeout_ms = cfg.getUInt(cfg_prefix + ".http_keep_alive_timeout_ms", 5000);
         http_connection_pool_size = cfg.getUInt(cfg_prefix + ".http_connection_pool_size", 1024);
+        min_upload_part_size = cfg.getUInt64(cfg_prefix + ".min_upload_part_size", 16 * 1024 * 1024);
+        max_single_part_upload_size = cfg.getUInt64(cfg_prefix + ".max_single_part_upload_size", 16 * 1024 * 1024);
 
         if (ak_id.empty())
             collectCredentialsFromEnv();

--- a/src/IO/S3Common.h
+++ b/src/IO/S3Common.h
@@ -150,7 +150,9 @@ public:
         int max_connections_ = 100,
         uint32_t http_keep_alive_timeout_ms_ = 5000,
         size_t http_connection_pool_size_ = 1024,
-        size_t slow_read_ms_ = 100)
+        size_t slow_read_ms_ = 100,
+        UInt64 min_upload_part_size_ = 16 * 1024 * 1024,
+        UInt64 max_single_part_upload_size_ = 16 * 1024 * 1024)
         : max_redirects(max_redirects_)
         , connect_timeout_ms(connect_timeout_ms_)
         , request_timeout_ms(request_timeout_ms_)
@@ -166,6 +168,8 @@ public:
         , http_keep_alive_timeout_ms(http_keep_alive_timeout_ms_)
         , http_connection_pool_size(http_connection_pool_size_)
         , slow_read_ms(slow_read_ms_)
+        , min_upload_part_size(min_upload_part_size_)
+        , max_single_part_upload_size(max_single_part_upload_size_)
     {
     }
 
@@ -194,6 +198,8 @@ public:
     uint32_t http_keep_alive_timeout_ms;
     size_t http_connection_pool_size;
     size_t slow_read_ms{100};
+    UInt64 min_upload_part_size;
+    UInt64 max_single_part_upload_size;
 };
 
 class S3Util


### PR DESCRIPTION
Fix S3 segment upload file part file size cannot be configured.
Added parameters' max_single.part_upload_size 'and' min_upload_part_size '

 https://github.com/ByConity/ByConity/issues/1679

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->

<!-- If you are doing this for the first time, it's recommended to read the lightweight Contributing to ByConity Documentation https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md guide first. -->

### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix S3 segment upload file part file size cannot be configured.
Added parameters' max_single.part_upload_size 'and' min_upload_part_size '
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---

Add a user-readable short description of the changes that should be added to https://github.com/ByConity/byconity.github.io below.

At a minimum, the following information should be added (but add more as needed).

- Motivation: 
It was found that the default part file size for S3 segmented uploads is set to a fixed value of 16MB. For mini, the size of the part file is too small, which leads to an increase in the number of files and can easily lead to performance issues in mini.
Configurable variables have been added here, and the part file size can be adjusted through configuration.

- Parameters:
Added two parameters, 'max_single.part_upload_size' and 'min_upload_part_size', with a default value of 16MB
The configuration is located under 'disks configuration' under 'storage_configuration'.

- Example use: 
```
    storage_configuration:
      disks:
        server_s3_disk_0:
          path: byconity_path
          endpoint: http://xxx.xxx.xxx.xxx:9000
          region: cn-beijing
          bucket: byconity-test
          ak_id: minioxxx
          ak_secret: minio123xxx
          type: bytes3
          is_virtual_hosted_style: false
          max_single_part_upload_size: 16777216
          min_upload_part_size: 16777216
```
-->
