### PR TITLE
fix unit test failure from ansi_nullify_grouping.sql

### DIFF
--- a/tests/queries/4_cnch_stateless/40057_ansi_nullify_grouping.sql
+++ b/tests/queries/4_cnch_stateless/40057_ansi_nullify_grouping.sql
@@ -1,12 +1,12 @@
 drop database if exists test_dql_crossjoin;
 create database if not exists test_dql_crossjoin;
 use test_dql_crossjoin;
-create table t01(`id` UInt64, `str_0` String,`date_0` Date)engine=CnchMergeTree order by id partition by date_0 TTL date_0+toIntervalDay(365);
+create table t01(`id` UInt64, `str_0` String,`date_0` Date)engine=CnchMergeTree order by id partition by date_0;
 insert into t01 values(1,'aaa','2023-06-12'),(2,'bbb','2023-06-12'),(3,'aaa','2023-06-13'),(1,'ddd','2023-06-14');
 insert into t01 values(5,'abc','2023-06-15'),(6,'def','2023-06-16');
-create table t02(`id` UInt64, `str_0` String,`date_0` Date)engine=CnchMergeTree order by id partition by date_0 TTL date_0+toIntervalDay(365);
+create table t02(`id` UInt64, `str_0` String,`date_0` Date)engine=CnchMergeTree order by id partition by date_0;
 insert into t02 values(100,'ppp','2023-06-12'),(101,'jkl','2023-06-12'),(102,'ghj','2023-06-13'),(103,'bnm','2023-06-14'),(6,'fgh','2023-06-17');
-create table t03(`id` UInt64, `str_0` String,`date_0` Date)engine=CnchMergeTree order by id partition by date_0 TTL date_0+toIntervalDay(365);
+create table t03(`id` UInt64, `str_0` String,`date_0` Date)engine=CnchMergeTree order by id partition by date_0;
 insert into t03 values(1000,'qwe','2023-06-15'),(1001,'wer','2023-06-16'),(1002,'ert','2023-06-17'),(1003,'rty','2023-06-18'),(100,'ppp','2023-06-12');
 insert into t02 values(4,'dfg','2023-06-17');
 insert into t03 values(5,'jkl','2023-06-16'),(1,'iop',today()),(2,'yui',today()),(4,'sdf',today());


### PR DESCRIPTION
Ansi nullify grouping test uses TTL 1 year for rows, which stales now. Removing such unnecessary TTL will make the test case more robust.