### PR TITLE
update debian builder and runner from 11.6 to 11.9

### DIFF
--- a/docker/debian/base/Dockerfile
+++ b/docker/debian/base/Dockerfile
@@ -10,7 +10,7 @@ RUN wget -qO foundationdb-clients.deb https://github.com/apple/foundationdb/rele
 RUN wget -qO tini https://github.com/krallin/tini/releases/download/v0.19.0/tini
 
 # Debian builder
-FROM debian:11.6 as debian-builder
+FROM debian:11.9 as debian-builder
 LABEL description="Debian image for compiling"
 LABEL org.opencontainers.image.source="https://github.com/ByConity/ByConity"
 
@@ -39,7 +39,7 @@ RUN ldconfig
 ENV CC=clang-11 CXX=clang++-11
 
 # Base runner image
-FROM debian:11.6-slim as debian-runner
+FROM debian:11.9-slim as debian-runner
 LABEL description="Base Debian image for runtime"
 LABEL org.opencontainers.image.source="https://github.com/ByConity/ByConity"
 


### PR DESCRIPTION
Automated container security check complains about several critical vulnerabilities when using debian 11.6

Upgrading to debian version 11.9 fixes those. If this change is undesired feel free to close this pull request. Thanks!

Here is the list:
* https://security-tracker.debian.org/tracker/CVE-2023-25775
* https://security-tracker.debian.org/tracker/CVE-2023-5178

Note:
I tried to test it with debian 12 but llvm installation has a bunch of issues with version llvm-12 and clang-12. Adding an issue from their repo as it might be relevant: https://github.com/llvm/llvm-project/issues/62475