### PR TITLE
Fix delayed index calculation when it filter all mark ranges

### DIFF
--- a/src/Storages/MergeTree/LateMaterialize/MergeTreeReverseSelectProcessorLM.cpp
+++ b/src/Storages/MergeTree/LateMaterialize/MergeTreeReverseSelectProcessorLM.cpp
@@ -18,9 +18,15 @@ try
 {
     if (is_first_task)
     {
-        firstTaskInitialization();
+        is_first_task = false;
+        if (!firstTaskInitialization())
+        {
+            readers.clear();
+            range_readers.clear();
+            part_detail.data_part.reset();
+            return false;
+        }
     }
-    is_first_task = false;
 
     if ((chunks.empty() && part_detail.ranges.empty()))
     {

--- a/src/Storages/MergeTree/LateMaterialize/MergeTreeSelectProcessorLM.cpp
+++ b/src/Storages/MergeTree/LateMaterialize/MergeTreeSelectProcessorLM.cpp
@@ -54,15 +54,13 @@ bool MergeTreeSelectProcessorLM::getNewTaskImpl()
 {
     try
     {
-        if (part_detail.ranges.empty())
+        if (part_detail.ranges.empty() || !firstTaskInitialization())
         {
             readers.clear();
             range_readers.clear();
             part_detail.data_part.reset();
             return false;
         }
-
-        firstTaskInitialization();
 
         auto size_predictor = (stream_settings.preferred_block_size_bytes == 0)
             ? nullptr
@@ -85,7 +83,7 @@ bool MergeTreeSelectProcessorLM::getNewTaskImpl()
     }
 }
 
-void MergeTreeSelectProcessorLM::firstTaskInitialization()
+bool MergeTreeSelectProcessorLM::firstTaskInitialization()
 {
     std::unique_ptr<roaring::Roaring> row_filter = nullptr;
     if (mark_ranges_filter_callback)
@@ -111,6 +109,7 @@ void MergeTreeSelectProcessorLM::firstTaskInitialization()
             *delete_bitmap &= *row_filter;
         }
     }
+    return !part_detail.ranges.empty();
 }
 
 }

--- a/src/Storages/MergeTree/LateMaterialize/MergeTreeSelectProcessorLM.h
+++ b/src/Storages/MergeTree/LateMaterialize/MergeTreeSelectProcessorLM.h
@@ -36,7 +36,7 @@ public:
 protected:
 
     bool getNewTaskImpl() override;
-    void firstTaskInitialization();
+    bool firstTaskInitialization();
 
     /// Used by Task
     Names required_columns;

--- a/src/Storages/MergeTree/MergeTreeReverseSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeReverseSelectProcessor.cpp
@@ -44,9 +44,13 @@ try
     }
     if (is_first_task)
     {
-        firstTaskInitialization();
+        is_first_task = false;
+        if (!firstTaskInitialization())
+        {
+            finish();
+            return false;
+        }
     }
-    is_first_task = false;
 
     /// We have some blocks to return in buffer.
     /// Return true to continue reading, but actually don't create a task.

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -77,11 +77,12 @@ try
         finish();
         return false;
     }
-    if (is_first_task)
-    {
-        firstTaskInitialization();
-    }
     is_first_task = false;
+    if (!firstTaskInitialization())
+    {
+        finish();
+        return false;
+    }
 
     task_columns = getReadTaskColumns(
         storage, storage_snapshot, part_detail.data_part,
@@ -112,7 +113,7 @@ catch (...)
     throw;
 }
 
-void MergeTreeSelectProcessor::firstTaskInitialization()
+bool MergeTreeSelectProcessor::firstTaskInitialization()
 {
     std::unique_ptr<roaring::Roaring> row_filter = nullptr;
     if (mark_ranges_filter_callback)
@@ -138,6 +139,7 @@ void MergeTreeSelectProcessor::firstTaskInitialization()
             *delete_bitmap &= *row_filter;
         }
     }
+    return !part_detail.ranges.empty();
 }
 
 void MergeTreeSelectProcessor::finish()

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.h
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.h
@@ -62,8 +62,8 @@ protected:
 
     bool getNewTask() override;
     /// Do extra mark range filter, row filter generation and delete bitmap
-    /// initialize
-    void firstTaskInitialization();
+    /// initialize, return if there are mark ranges to read
+    bool firstTaskInitialization();
 
     /// Used by Task
     Names required_columns;

--- a/tests/queries/4_cnch_stateless/00941_read_in_partition_order.sql
+++ b/tests/queries/4_cnch_stateless/00941_read_in_partition_order.sql
@@ -97,3 +97,10 @@ create table norder5 (ts DateTime, c1 Int64) engine = CnchMergeTree partition by
 insert into norder5 select toDateTime('2024-06-01 00:00:00') + interval number hour, 1 from numbers(3);
 select * from norder5 where c1 = 1 order by ts limit 1; -- { serverError 277 }
 drop table norder5;
+
+drop table if exists inorder_filter_all_ranges;
+create table inorder_filter_all_ranges (ts DateTime, value String, index val_idx value type inverted granularity 1) engine = CnchMergeTree partition by toDate(ts) order by ts;
+insert into inorder_filter_all_ranges values ('2024-11-04 00:00:00', 'abc def')('2024-11-03 00:00:00', 'ghi jkl');
+select * from inorder_filter_all_ranges where hasToken(value, 'a') order by ts asc;
+select * from inorder_filter_all_ranges where hasToken(value, 'a') order by ts desc;
+drop table inorder_filter_all_ranges;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->

<!-- If you are doing this for the first time, it's recommended to read the lightweight Contributing to ByConity Documentation https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md guide first. -->

### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Bug Fix


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix select processors when it delay index calculation and filter all mark ranges

Thanks @ArthurZou for the feedback on this issue