### PR TITLE
change /api to non strict path in http handler factory to fix api calls

### DIFF
--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -176,7 +176,7 @@ void addCommonDefaultHandlersFactory(HTTPRequestHandlerFactoryMain & factory, IS
     factory.addHandler(ping_handler);
 
     auto api_handler = std::make_shared<HandlingRuleHTTPHandlerFactory<APIRequestHandler>>(server);
-    api_handler->attachStrictPath("/api");
+    api_handler->attachNonStrictPath("/api");
     api_handler->allowGetAndHeadRequest();
     factory.addHandler(api_handler);
 


### PR DESCRIPTION
### Changelog category <!-- please remove the below items and leave one that you choose -->:
- Bug Fix


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Change /api endpoint registration to non strict to support /api/resource_action?action=... type calls.

In Byconity helm repository, workers call prestop hook before terminating to stop new tasks coming to them. This hook is currently broken because HTTPHandlerFactory does not register "/api" URI correctly.

