### PR TITLE
Fix build with clang 17

### DIFF
--- a/src/benchmark/disk_cache_benchmark.cpp
+++ b/src/benchmark/disk_cache_benchmark.cpp
@@ -160,7 +160,7 @@ public:
                         buffer_permutation[i % 100].view(),
                         [](HybridCache::Status status, HybridCache::HashedKey) {
                             if (status != HybridCache::Status::Ok)
-                                printf("insert failed %d\n", status);
+                                printf("insert failed %d\n", static_cast<int>(status));
                         },
                         HybridCache::EngineTag::UncompressedCache);
             };
@@ -222,7 +222,7 @@ public:
                         buffer_permutation[i % 100].view(),
                         [](HybridCache::Status status, HybridCache::HashedKey) {
                             if (status != HybridCache::Status::Ok)
-                                printf("insert faield %d\n", status);
+                                printf("insert faield %d\n", static_cast<int>(status));
                         },
                         HybridCache::EngineTag::UncompressedCache);
             };
@@ -236,7 +236,7 @@ public:
                         HybridCache::makeHashKey(&key_permutation[i], sizeof(Int64)),
                         [](HybridCache::Status status, HybridCache::HashedKey, HybridCache::Buffer) {
                             if (status != HybridCache::Status::Ok)
-                                printf("lookup failed %d\n", status);
+                                printf("lookup failed %d\n", static_cast<int>(status));
                         },
                         HybridCache::EngineTag::UncompressedCache);
             };


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->

<!-- If you are doing this for the first time, it's recommended to read the lightweight Contributing to ByConity Documentation https://github.com/ByConity/ByConity/blob/master/CONTRIBUTING.md guide first. -->

### Changelog category <!-- please remove the below items and leave one that you choose -->:

- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix build with clang 17
```
[32/34] Building CXX object src/CMakeFiles/disk_cache_benchmark.dir/benchmark/disk_cache_benchmark.cpp.o
FAILED: src/CMakeFiles/disk_cache_benchmark.dir/benchmark/disk_cache_benchmark.cpp.o 
/usr/bin/ccache /usr/lib/llvm-17/bin/clang++ -DAWS_SDK_VERSION_MAJOR=1 -DAWS_SDK_VERSION_MINOR=10 -DAWS_SDK_VERSION_PATCH=36 -DBOOST_ASIO_HAS_STD_INVOKE_RESULT=1 -DBOOST_ASIO_STANDALONE=1 -DBOOST_TIMER_ENABLE_DEPRECATED=1 -DBUNDLED_STATIC_JEMALLOC=1 -DCARES_STATICLIB -DENABLE_MULTITARGET_CODE=1 -DGFLAGS_IS_A_DLL=0 -DPACKAGE_VERSION=\"1.6.0\" -DPOCO_ENABLE_CPP11 -DPOCO_HAVE_FD_EPOLL -DPOCO_OS_FAMILY_UNIX -DPOCO_UNBUNDLED_ZLIB -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -DUNALIGNED_OK -DUSE_HYPERSCAN=1 -DUSE_JEMALLOC=1 -DUSE_REPLXX=1 -DWITH_COVERAGE=0 -DWITH_GZFILEOP -DX86_64 -DZLIB_COMPAT -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -Ddisk_cache_benchmark_EXPORTS -I/data1/home/wujianchao/project/jd/byconity/contrib/sentry-native/include -I/data1/home/wujianchao/project/jd/byconity/cmake-build-debug/includes/configs -I"/data1/home/wujianchao/project/jd/byconity/src/benchmark/*.h" -I/data1/home/wujianchao/project/jd/byconity/rust/BLAKE3/include -I/data1/home/wujianchao/project/jd/byconity/src -I/data1/home/wujianchao/project/jd/byconity/cmake-build-debug/src -I/data1/home/wujianchao/project/jd/byconity/cmake-build-debug/src/Core/include -I/data1/home/wujianchao/project/jd/byconity/contrib/snappy -I/data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/snappy -I/data1/home/wujianchao/project/jd/byconity/base/common/.. -I/data1/home/wujianchao/project/jd/byconity/cmake-build-debug/base/common/.. -I/data1/home/wujianchao/project/jd/byconity/base/common/ch_rust::skim -I/data1/home/wujianchao/project/jd/byconity/cmake-build-debug/rust/skim/include -I/data1/home/wujianchao/project/jd/byconity/contrib/cityhash102/include -I/data1/home/wujianchao/project/jd/byconity/contrib/cctz/include -I/data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/zlib-ng -I/data1/home/wujianchao/project/jd/byconity/contrib/zlib-ng -I/data1/home/wujianchao/project/jd/byconity/base/pcg-random/. -I/data1/home/wujianchao/project/jd/byconity/contrib/ipdb -I/data1/home/wujianchao/project/jd/byconity/contrib/json-c -I/data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/jsonc-cmake -I/data1/home/wujianchao/project/jd/byconity/contrib/maxminddb -I/data1/home/wujianchao/project/jd/byconity/contrib/maxminddb/include -I/data1/home/wujianchao/project/jd/byconity/base/metrics2 -I/data1/home/wujianchao/project/jd/byconity/contrib/consistent-hashing -I/data1/home/wujianchao/project/jd/byconity/src/Catalog -I/data1/home/wujianchao/project/jd/byconity/base/daemon/.. -I/data1/home/wujianchao/project/jd/byconity/src/Bridge/.. -I/data1/home/wujianchao/project/jd/byconity/base/loggers/.. -I/data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/grpc/third_party/cares/cares -I/data1/home/wujianchao/project/jd/byconity/contrib/grpc/third_party/cares/cares -I/data1/home/wujianchao/project/jd/byconity/contrib/libpq -I/data1/home/wujianchao/project/jd/byconity/contrib/libpq/include -I/data1/home/wujianchao/project/jd/byconity/contrib/rapidjson/include -I/data1/home/wujianchao/project/jd/byconity/contrib/libstemmer_c/include -I/data1/home/wujianchao/project/jd/byconity/contrib/wordnet-blast -I/data1/home/wujianchao/project/jd/byconity/contrib/lemmagen-c/include -I/data1/home/wujianchao/project/jd/byconity/base/libbiginteger -I/data1/home/wujianchao/project/jd/byconity/cmake-build-debug/rust/BLAKE3/include -I/data1/home/wujianchao/project/jd/byconity/contrib/benchmark/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/sparsehash-c11 -isystem /data1/home/wujianchao/project/jd/byconity/base/glibc-compatibility/memcpy -isystem /data1/home/wujianchao/project/jd/byconity/contrib/llvm-project/libcxx/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/llvm-project/libcxxabi/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/libunwind/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/parallel-hashmap -isystem /data1/home/wujianchao/project/jd/byconity/contrib/libpqxx/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/hivemetastore -isystem /data1/home/wujianchao/project/jd/byconity/contrib/rocksdb/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/orc/c++/include -isystem /data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/orc/c++/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/AMQP-CPP/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/libuv/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/AMQP-CPP -isystem /data1/home/wujianchao/project/jd/byconity/contrib/sparse-map/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/folly -isystem /data1/home/wujianchao/project/jd/byconity/contrib/folly-cmake -isystem /data1/home/wujianchao/project/jd/byconity/contrib/libevent/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/libevent-cmake/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/fmtlib-cmake/../fmtlib/include -isystem /data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/glog-cmake -isystem /data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/gflags/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/libhdfs3-open/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/miniselect/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/pdqsort -isystem /data1/home/wujianchao/project/jd/byconity/contrib/croaring/cpp -isystem /data1/home/wujianchao/project/jd/byconity/contrib/croaring/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/fast_float/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/protobuf/src -isystem /data1/home/wujianchao/project/jd/byconity/contrib/xz/src/liblzma/api -isystem /data1/home/wujianchao/project/jd/byconity/contrib/zstd/lib -isystem /data1/home/wujianchao/project/jd/byconity/contrib/re2 -isystem /data1/home/wujianchao/project/jd/byconity/contrib -isystem /data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/incubator-brpc/output/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/jemalloc-cmake/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/boost -isystem /data1/home/wujianchao/project/jd/byconity/contrib/poco/Net/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/poco/Foundation/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/poco/NetSSL_OpenSSL/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/poco/Crypto/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/boringssl/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/poco/Util/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/poco/JSON/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/poco/XML/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/replxx/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/magic_enum/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/double-conversion -isystem /data1/home/wujianchao/project/jd/byconity/contrib/dragonbox/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/poco/Zip/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/abseil-cpp -isystem /data1/home/wujianchao/project/jd/byconity/contrib/llvm-project/llvm/include -isystem /data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/llvm-project/llvm/include -isystem /data1/home/wujianchao/project/jd/byconity/cmake-build-debug/src/Protos/.. -isystem /data1/home/wujianchao/project/jd/byconity/contrib/aws/src/aws-cpp-sdk-core/include -isystem /data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/aws-cmake/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/aws/generated/src/aws-cpp-sdk-s3/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/aws/generated/src/aws-cpp-sdk-s3-crt/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/aws/generated/src/aws-cpp-sdk-glue/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/aws-c-auth/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/aws-c-common/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/aws-c-io/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/aws-crt-cpp/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/aws-c-mqtt/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/aws-c-http/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/aws-c-s3/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/aws-c-sdkutils/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/NuRaft/include -isystem /data1/home/wujianchao/project/jd/byconity/libs/libdaemon/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/librdkafka-cmake/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/librdkafka/src -isystem /data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/librdkafka-cmake/auxdir -isystem /data1/home/wujianchao/project/jd/byconity/contrib/cppkafka/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/foundationdb/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/thrift/lib/cpp/src -isystem /data1/home/wujianchao/project/jd/byconity/contrib/murmurhash/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/libmetrohash/src -isystem /data1/home/wujianchao/project/jd/byconity/contrib/libfarmhash -isystem /data1/home/wujianchao/project/jd/byconity/contrib/grpc/include -isystem /data1/home/wujianchao/project/jd/byconity/cmake-build-debug/src/Server/grpc_protos -isystem /data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/liburing/src/include-compat -isystem /data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/liburing/src/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/liburing/src/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/simdjson/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/cppjieba/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/cppjieba/deps/limonp/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/ulid-c/include -isystem /data1/home/wujianchao/project/jd/byconity/cmake-build-debug/datasketches-prefix/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/wyhash -isystem /data1/home/wujianchao/project/jd/byconity/contrib/base64 -isystem /data1/home/wujianchao/project/jd/byconity/contrib/fastops -isystem /data1/home/wujianchao/project/jd/byconity/contrib/hashidsxx -isystem /data1/home/wujianchao/project/jd/byconity/contrib/morton-nd/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/libdivide/. -isystem /data1/home/wujianchao/project/jd/byconity/contrib/xxHash -isystem /data1/home/wujianchao/project/jd/byconity/contrib/icu/icu4c/source/i18n -isystem /data1/home/wujianchao/project/jd/byconity/contrib/icu/icu4c/source/common -isystem /data1/home/wujianchao/project/jd/byconity/contrib/h3/src/h3lib/include -isystem /data1/home/wujianchao/project/jd/byconity/cmake-build-debug/contrib/h3/src/h3lib/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/hyperscan/src -isystem /data1/home/wujianchao/project/jd/byconity/contrib/stats/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/gcem/include -isystem /data1/home/wujianchao/project/jd/byconity/contrib/cld2/public -isystem /data1/home/wujianchao/project/jd/byconity/contrib/libc-headers/x86_64-linux-gnu -isystem /data1/home/wujianchao/project/jd/byconity/contrib/libc-headers -fdiagnostics-color=always -fsized-deallocation -fno-omit-frame-pointer  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -falign-functions=32 -mbranches-within-32B-boundaries -ffp-contract=off   -Wall -Wno-unused-command-line-argument  -fdiagnostics-absolute-paths -Werror -Wextra -Wpedantic -Wno-vla-extension -Wno-zero-length-array -Wno-c11-extensions -Wcomma -Wconditional-uninitialized -Wcovered-switch-default -Wdeprecated -Wembedded-directive -Wempty-init-stmt -Wextra-semi-stmt -Wextra-semi -Wgnu-case-range -Winconsistent-missing-destructor-override -Wnewline-eof -Wold-style-cast -Wrange-loop-analysis -Wredundant-parens -Wreserved-id-macro -Wshadow-field -Wshadow-uncaptured-local -Wshadow -Wstring-plus-int -Wundef -Wunreachable-code-return -Wunreachable-code -Wunused-exception-parameter -Wunused-macros -Wunused-member-function -Weverything -Wno-c++98-compat-pedantic -Wno-c++98-compat -Wno-c99-extensions -Wno-conversion -Wno-ctad-maybe-unsupported -Wno-deprecated-dynamic-exception-spec -Wno-disabled-macro-expansion -Wno-documentation-unknown-command -Wno-double-promotion -Wno-exit-time-destructors -Wno-float-equal -Wno-global-constructors -Wno-missing-prototypes -Wno-missing-variable-declarations -Wno-nested-anon-types -Wno-packed -Wno-padded -Wno-shift-sign-overflow -Wno-sign-conversion -Wno-switch-enum -Wno-undefined-func-template -Wno-unused-template -Wno-vla -Wno-weak-template-vtables -Wno-weak-vtables -Wno-covered-switch-default -Wno-missing-noreturn -Wno-switch-default -Wno-reserved-identifier -Wno-unsafe-buffer-usage -Wno-implicit-function-declaration -Wno-missing-field-initializers -Wno-deprecated-copy -Wno-deprecated-copy-with-dtor -Wno-deprecated-builtins -Wno-shadow-uncaptured-local -Wno-shadow -Wno-cast-function-type -Wno-cast-function-type-strict -Wno-unused-but-set-variable -Wno-unused-but-set-parameter -Wno-deprecated-redundant-constexpr-static-def -Wno-enum-constexpr-conversion -Wno-documentation-html -Wno-documentation -Wno-unsafe-buffer-usage -Wno-thread-safety-negative -Wno-zero-as-null-pointer-constant -g -O0 -g3 -ggdb3 -fno-inline  -D_LIBCPP_DEBUG=0 -std=c++23 -fcolor-diagnostics   -D OS_LINUX -Werror -Wall -nostdinc++ -pthread -Wno-error -Werror -MD -MT src/CMakeFiles/disk_cache_benchmark.dir/benchmark/disk_cache_benchmark.cpp.o -MF src/CMakeFiles/disk_cache_benchmark.dir/benchmark/disk_cache_benchmark.cpp.o.d -o src/CMakeFiles/disk_cache_benchmark.dir/benchmark/disk_cache_benchmark.cpp.o -c /data1/home/wujianchao/project/jd/byconity/src/benchmark/disk_cache_benchmark.cpp
/data1/home/wujianchao/project/jd/byconity/src/benchmark/disk_cache_benchmark.cpp:163:62: error: format specifies type 'int' but the argument has type 'HybridCache::Status' [-Werror,-Wformat]
  163 |                                 printf("insert failed %d\n", status);
      |                                                       ~~     ^~~~~~
      |                                                              static_cast<int>( )
/data1/home/wujianchao/project/jd/byconity/src/benchmark/disk_cache_benchmark.cpp:225:62: error: format specifies type 'int' but the argument has type 'HybridCache::Status' [-Werror,-Wformat]
  225 |                                 printf("insert faield %d\n", status);
      |                                                       ~~     ^~~~~~
      |                                                              static_cast<int>( )
/data1/home/wujianchao/project/jd/byconity/src/benchmark/disk_cache_benchmark.cpp:239:62: error: format specifies type 'int' but the argument has type 'HybridCache::Status' [-Werror,-Wformat]
  239 |                                 printf("lookup failed %d\n", status);
      |                                                       ~~     ^~~~~~
      |                                                              static_cast<int>( )
3 errors generated.
```

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---

Add a user-readable short description of the changes that should be added to https://github.com/ByConity/byconity.github.io below.

At a minimum, the following information should be added (but add more as needed).

- Motivation: Why is this function, table engine, etc. useful to ByConity users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
