### PR TITLE
Fix LRUCache iterator typo

### DIFF
--- a/src/Common/LRUCache.h
+++ b/src/Common/LRUCache.h
@@ -151,7 +151,7 @@ public:
 
         auto & name_index = indexes.template get<name_tag>();
         auto it = name_index.equal_range(name);
-        if (it.frist == it.second)
+        if (it.first == it.second)
             return;
 
         name_index.erase(it.first, it.second);


### PR DESCRIPTION
Summary
- Fix a typo in LRUCache::drop(const String&) so the equal_range result uses it.first.

Testing
- git diff --check
- rg -n "it\.frist|it\.first == it\.second" src/Common/LRUCache.h

Notes
- Fixes #2015